### PR TITLE
Phase 0: lists ID-range reservation (books data migration)

### DIFF
--- a/docs/features/user-lists.md
+++ b/docs/features/user-lists.md
@@ -195,6 +195,9 @@ The `/user_lists/:id` alias above resolves a list by its **raw primary key**, so
 |---|---|---|
 | `users` | `[1, 150_000)` | `>= 150_000` |
 | `user_lists` | `[1, 1_000_000)` | `>= 1_000_000` |
+| `lists` | `[1, 10_000)` | `>= 10_000` |
+
+`lists` was reserved in a later migration (`db/migrate/*_reserve_lists_id_range.rb`) so legacy `/lists/:id` URLs keep resolving after import. Its ceiling (`10_000`) must exceed the **new-app** `lists` `MAX(id)` at run time (the relocation is an additive shift, collision-free only when all rows are below the ceiling) — re-confirm before running in production. The reservation also remaps the one **polymorphic** reference to lists, `ai_chats.parent` (`parent_type = 'List'`), which has no FK. See `docs/superpowers/plans/2026-07-03-lists-id-range-reservation.md`.
 
 The **per-table** ceilings live in `Services::BooksMigration::RESERVED_CEILINGS` (`app/lib/services/books_migration.rb`), reused by the migration and any future books ETL. The migration `db/migrate/20260612235510_reserve_books_id_ranges.rb` calls `Services::BooksMigration::IdRangeReservationService`, which (in one transaction) relocates any existing new-app rows up by their table's ceiling — remapping every FK that references `users`/`user_lists` (see `FOREIGN_KEYS` in the same file) — then bumps both sequences above their ceiling. It is idempotent (safe to re-run) and irreversible by design (restore from a snapshot to undo).
 

--- a/docs/superpowers/plans/2026-07-03-lists-id-range-reservation.md
+++ b/docs/superpowers/plans/2026-07-03-lists-id-range-reservation.md
@@ -1,0 +1,431 @@
+# Lists ID-Range Reservation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reserve the low primary-key range on the shared `lists` table so legacy Greatest Books list IDs can be imported unchanged (URL continuity) without colliding with the music/games/movies lists already in the new app.
+
+**Architecture:** Extend the existing, generic `Services::BooksMigration` reservation (which already reserved `users` ≤150k and `user_lists` ≤1M) to also cover `lists`. Add `lists` to `RESERVED_CEILINGS` and `FOREIGN_KEYS`, add a new `POLYMORPHIC_FOREIGN_KEYS` map for the one polymorphic reference to lists (`ai_chats.parent`), and two service fixes: (a) re-add only the FKs that were actually dropped (so the FK-less `ranked_lists.list_id` doesn't get a brand-new FK), and (b) shift polymorphic `ai_chats.parent_id`. A thin, idempotent migration runs the service; a snapshot-first operational run applies it in production.
+
+**Tech Stack:** Rails 8.1, PostgreSQL 17, Minitest + fixtures, `Services::` object with a `{success:, data:/error:}` result hash. Raw SQL via `ActiveRecord::Base.connection`.
+
+## Global Constraints
+
+- Run all commands from `web-app/`.
+- Lint with `bundle exec standardrb` (NOT rubocop). Tests: `bin/rails test`.
+- **`lists` ceiling = `10_000`.** This value MUST, at run time, exceed the **new-app** `lists` `MAX(id)` (dev is 1,475), because the relocation is an additive `id + ceiling` shift that is only collision-free when every existing row is below the ceiling. It must also exceed the **legacy** `lists` `MAX(id)` (1,175) at import time so imported book lists fit in `[1, ceiling)`. Before the production run, confirm `SELECT max(id) FROM lists` (new-app prod) is well under `10_000`; raise the ceiling if not (zero cost on a bigint PK).
+- The reservation service must remain **idempotent** (safe to re-run: a second run is a no-op) and run in a **single transaction**.
+- **Do not add any new domain foreign key.** In particular, `ranked_lists.list_id` currently has no DB-level FK; the reservation must shift it but must NOT create an FK for it.
+- Production is an operational, snapshot-first step — not performed by this plan's automated run.
+- `db/schema.rb` does not capture sequence `RESTART` values; `db:schema:load` (CI/fresh DBs) starts sequences at 1. That is acceptable — the reservation only needs to hold where the books import runs (prod + dev).
+
+## Columns that reference `lists.id` (authoritative — verified against `db/schema.rb` @ 2026_07_01_163004 and `pg_constraint`)
+
+| Child table | Column | Real DB FK? |
+|---|---|---|
+| `list_items` | `list_id` | yes |
+| `list_penalties` | `list_id` | yes |
+| `ranked_lists` | `list_id` | **no** (shift only, never add FK) |
+| `ranking_configurations` | `primary_mapped_list_id` | yes |
+| `ranking_configurations` | `secondary_mapped_list_id` | yes |
+| `ai_chats` | `parent_id` (where `parent_type = 'List'`) | polymorphic — no FK |
+
+---
+
+### Task 1: Extend the reservation service to cover `lists`
+
+**Files:**
+- Modify: `web-app/app/lib/services/books_migration.rb` (add `lists` to `RESERVED_CEILINGS`/`FOREIGN_KEYS`; add `POLYMORPHIC_FOREIGN_KEYS`; update module comment)
+- Modify: `web-app/app/lib/services/books_migration/id_range_reservation_service.rb` (drop→collect, re-add only dropped, add polymorphic shift)
+- Test: `web-app/test/lib/services/books_migration/id_range_reservation_service_test.rb`
+
+**Interfaces:**
+- Consumes: `Services::BooksMigration::RESERVED_CEILINGS`, `FOREIGN_KEYS`, `POLYMORPHIC_FOREIGN_KEYS` (constants); `Services::BooksMigration::IdRangeReservationService.call` → `{success: true, data: {...}}` or `{success: false, error: String}`.
+- Produces: after `.call`, no `lists` row has `id < 10_000`; every column above is shifted by `10_000` for rows that were below it; the `lists` sequence is `>= 10_000`; **no** `ranked_lists → lists` FK exists.
+
+- [ ] **Step 1: Rename the misleading test constant and add the lists ceiling constant**
+
+In `test/lib/services/books_migration/id_range_reservation_service_test.rb`, the constant currently named `LISTS_CEILING` actually fetches the `user_lists` ceiling. Rename it and add a real lists ceiling. Replace the two constant lines at the top of the class:
+
+```ruby
+  USERS_CEILING = Services::BooksMigration::RESERVED_CEILINGS.fetch("users")
+  USER_LISTS_CEILING = Services::BooksMigration::RESERVED_CEILINGS.fetch("user_lists")
+  LISTS_CEILING = Services::BooksMigration::RESERVED_CEILINGS.fetch("lists")
+```
+
+Then update the two existing references to the old name:
+- In test "relocates reserved-range rows above the ceiling and remaps their FKs", change `RESERVED_LIST_ID + LISTS_CEILING` (both occurrences that refer to `user_lists`) to `RESERVED_LIST_ID + USER_LISTS_CEILING`.
+- In test "leaves no users or user_lists rows below the ceiling", change `WHERE id < #{LISTS_CEILING}` (the `user_lists` assertion) to `WHERE id < #{USER_LISTS_CEILING}`.
+
+- [ ] **Step 2: Seed lists + all its referencing rows in the test setup**
+
+In the same file, replace the `lists` insert inside `seed_reserved_range_rows` (the `RESERVED_OTHER_LIST_ID` row) and append the child/reference rows. Add these constants next to the existing `RESERVED_*` constants:
+
+```ruby
+  RESERVED_LIST_ITEM_ID = 21
+  RESERVED_RC_ID = 31
+  RESERVED_RANKED_LIST_ID = 41
+  RESERVED_PENALTY_ID = 51
+  RESERVED_LIST_PENALTY_ID = 61
+  RESERVED_AI_CHAT_ID = 71
+```
+
+Append to the end of `seed_reserved_range_rows` (the `lists` row at `RESERVED_OTHER_LIST_ID = 11` is already seeded earlier in that method; keep it):
+
+```ruby
+    @conn.execute(<<~SQL)
+      INSERT INTO list_items (id, list_id, verified, created_at, updated_at)
+      VALUES (#{RESERVED_LIST_ITEM_ID}, #{RESERVED_OTHER_LIST_ID}, false, now(), now())
+    SQL
+    @conn.execute(<<~SQL)
+      INSERT INTO ranking_configurations
+        (id, type, name, primary_mapped_list_id, secondary_mapped_list_id, created_at, updated_at)
+      VALUES (#{RESERVED_RC_ID}, 'Games::RankingConfiguration', 'Reserved RC',
+              #{RESERVED_OTHER_LIST_ID}, #{RESERVED_OTHER_LIST_ID}, now(), now())
+    SQL
+    @conn.execute(<<~SQL)
+      INSERT INTO ranked_lists (id, list_id, ranking_configuration_id, created_at, updated_at)
+      VALUES (#{RESERVED_RANKED_LIST_ID}, #{RESERVED_OTHER_LIST_ID}, #{RESERVED_RC_ID}, now(), now())
+    SQL
+    @conn.execute(<<~SQL)
+      INSERT INTO penalties (id, type, name, created_at, updated_at)
+      VALUES (#{RESERVED_PENALTY_ID}, 'Global::Penalty', 'Reserved Penalty', now(), now())
+    SQL
+    @conn.execute(<<~SQL)
+      INSERT INTO list_penalties (id, list_id, penalty_id, created_at, updated_at)
+      VALUES (#{RESERVED_LIST_PENALTY_ID}, #{RESERVED_OTHER_LIST_ID}, #{RESERVED_PENALTY_ID}, now(), now())
+    SQL
+    @conn.execute(<<~SQL)
+      INSERT INTO ai_chats (id, model, parent_type, parent_id, created_at, updated_at)
+      VALUES (#{RESERVED_AI_CHAT_ID}, 'test-model', 'List', #{RESERVED_OTHER_LIST_ID}, now(), now())
+    SQL
+```
+
+- [ ] **Step 3: Fix the existing `submitted_by_id` assertion (the lists row now relocates)**
+
+In test "relocates reserved-range rows above the ceiling and remaps their FKs", the `lists` row at id 11 will now be relocated to `11 + LISTS_CEILING`. Change the `lists.submitted_by_id` assertion's WHERE clause:
+
+```ruby
+    # lists.submitted_by_id -> users remapped (users ceiling); the lists row itself relocated by LISTS_CEILING.
+    assert_equal RESERVED_USER_ID + USERS_CEILING,
+      @conn.select_value("SELECT submitted_by_id FROM lists WHERE id = #{RESERVED_OTHER_LIST_ID + LISTS_CEILING}").to_i
+```
+
+- [ ] **Step 4: Write the failing lists-reservation test**
+
+Add these test methods to the file:
+
+```ruby
+  test "relocates lists and remaps every column that references lists.id" do
+    result = Services::BooksMigration::IdRangeReservationService.call
+    assert result[:success], "service should succeed: #{result[:error]}"
+
+    relocated = RESERVED_OTHER_LIST_ID + LISTS_CEILING
+
+    assert_equal relocated, relocated_id("lists", RESERVED_OTHER_LIST_ID)
+    assert_equal relocated,
+      @conn.select_value("SELECT list_id FROM list_items WHERE id = #{RESERVED_LIST_ITEM_ID}").to_i
+    assert_equal relocated,
+      @conn.select_value("SELECT list_id FROM ranked_lists WHERE id = #{RESERVED_RANKED_LIST_ID}").to_i
+    assert_equal relocated,
+      @conn.select_value("SELECT list_id FROM list_penalties WHERE id = #{RESERVED_LIST_PENALTY_ID}").to_i
+    assert_equal relocated,
+      @conn.select_value("SELECT primary_mapped_list_id FROM ranking_configurations WHERE id = #{RESERVED_RC_ID}").to_i
+    assert_equal relocated,
+      @conn.select_value("SELECT secondary_mapped_list_id FROM ranking_configurations WHERE id = #{RESERVED_RC_ID}").to_i
+  end
+
+  test "remaps the polymorphic ai_chats reference to a relocated list" do
+    Services::BooksMigration::IdRangeReservationService.call
+
+    assert_equal RESERVED_OTHER_LIST_ID + LISTS_CEILING,
+      @conn.select_value("SELECT parent_id FROM ai_chats WHERE id = #{RESERVED_AI_CHAT_ID}").to_i
+  end
+
+  test "does not create a foreign key for the FK-less ranked_lists.list_id" do
+    refute @conn.foreign_key_exists?("ranked_lists", "lists", column: "list_id"),
+      "precondition: ranked_lists.list_id must have no FK"
+
+    Services::BooksMigration::IdRangeReservationService.call
+
+    refute @conn.foreign_key_exists?("ranked_lists", "lists", column: "list_id"),
+      "reservation must not add a ranked_lists -> lists FK"
+  end
+
+  test "leaves no lists rows below the lists ceiling" do
+    Services::BooksMigration::IdRangeReservationService.call
+
+    assert_equal 0, @conn.select_value("SELECT COUNT(*) FROM lists WHERE id < #{LISTS_CEILING}").to_i
+  end
+
+  test "next List create lands at or above the lists ceiling" do
+    Services::BooksMigration::IdRangeReservationService.call
+
+    list = Books::List.create!(name: "Post-reservation List")
+    assert_operator list.id, :>=, LISTS_CEILING
+  end
+
+  test "is idempotent for lists: a second run does not shift the list again" do
+    assert Services::BooksMigration::IdRangeReservationService.call[:success]
+    relocated = relocated_id("lists", RESERVED_OTHER_LIST_ID)
+
+    assert Services::BooksMigration::IdRangeReservationService.call[:success]
+    assert_equal relocated, relocated_id("lists", RESERVED_OTHER_LIST_ID)
+  end
+
+  test "a simulated book-list import at a low reserved id succeeds without collision" do
+    Services::BooksMigration::IdRangeReservationService.call
+
+    @conn.execute(<<~SQL)
+      INSERT INTO lists (id, type, name, status, estimated_quality, created_at, updated_at)
+      VALUES (42, 'Books::List', 'Imported Book List', 0, 0, now(), now())
+    SQL
+
+    assert_equal 42, @conn.select_value("SELECT id FROM lists WHERE id = 42").to_i
+    assert List.exists?(42), "book list at reserved id 42 should be findable"
+  end
+```
+
+- [ ] **Step 5: Run the new tests — verify they FAIL**
+
+Run: `bin/rails test test/lib/services/books_migration/id_range_reservation_service_test.rb`
+Expected: FAIL — `KeyError: key not found: "lists"` from `RESERVED_CEILINGS.fetch("lists")` (the `lists` ceiling constant does not exist yet).
+
+- [ ] **Step 6: Add `lists` to the reservation constants + the polymorphic map**
+
+In `app/lib/services/books_migration.rb`, update the module comment's first sentence to name `lists`, then set the three constants:
+
+```ruby
+    RESERVED_CEILINGS = {
+      "users" => 150_000,
+      "user_lists" => 1_000_000,
+      "lists" => 10_000
+    }.freeze
+
+    FOREIGN_KEYS = {
+      "users" => [
+        ["ai_chats", "user_id"],
+        ["domain_roles", "user_id"],
+        ["external_links", "submitted_by_id"],
+        ["lists", "submitted_by_id"],
+        ["penalties", "user_id"],
+        ["ranking_configurations", "user_id"],
+        ["user_lists", "user_id"]
+      ],
+      "user_lists" => [
+        ["user_list_items", "user_list_id"]
+      ],
+      "lists" => [
+        ["list_items", "list_id"],
+        ["list_penalties", "list_id"],
+        ["ranked_lists", "list_id"],
+        ["ranking_configurations", "primary_mapped_list_id"],
+        ["ranking_configurations", "secondary_mapped_list_id"]
+      ]
+    }.freeze
+
+    # Polymorphic references have no DB FK. Rails stores the STI *base* class name
+    # in the `_type` column, so every list's ai_chat is `parent_type = "List"`.
+    # Format: [child_table, id_column, type_column, type_value].
+    POLYMORPHIC_FOREIGN_KEYS = {
+      "lists" => [
+        ["ai_chats", "parent_id", "parent_type", "List"]
+      ]
+    }.freeze
+```
+
+- [ ] **Step 7: Make the service re-add only dropped FKs and shift polymorphic refs**
+
+In `app/lib/services/books_migration/id_range_reservation_service.rb`, replace `call`, `drop_foreign_keys`, and `add_foreign_keys`, and add `relocate_polymorphic_rows`:
+
+```ruby
+      def call
+        ActiveRecord::Base.transaction do
+          dropped = drop_foreign_keys
+          relocate_rows
+          relocate_polymorphic_rows
+          add_foreign_keys(dropped)
+          bump_sequences
+        end
+        success({ceilings: RESERVED_CEILINGS})
+      rescue => e
+        failure(e.message)
+      end
+```
+
+```ruby
+      # Polymorphic references have no FK to drop/re-add; shift the id column for
+      # rows whose *_type matches the reserved table, by that table's ceiling.
+      def relocate_polymorphic_rows
+        POLYMORPHIC_FOREIGN_KEYS.each do |table, refs|
+          ceiling = RESERVED_CEILINGS.fetch(table)
+          refs.each do |child, id_column, type_column, type_value|
+            connection.execute(
+              "UPDATE #{child} SET #{id_column} = #{id_column} + #{ceiling} " \
+              "WHERE #{type_column} = #{connection.quote(type_value)} AND #{id_column} < #{ceiling}"
+            )
+          end
+        end
+      end
+```
+
+```ruby
+      # Returns the FKs it actually dropped, so add_foreign_keys re-adds only
+      # those — a column in FOREIGN_KEYS without a real DB FK (ranked_lists.list_id)
+      # is shifted but must NOT gain a new FK.
+      def drop_foreign_keys
+        dropped = []
+        each_foreign_key do |child, column, table|
+          if connection.foreign_key_exists?(child, table, column: column)
+            connection.remove_foreign_key(child, table, column: column)
+            dropped << [child, column, table]
+          end
+        end
+        dropped
+      end
+
+      # Re-adding a validated FK forces Postgres to verify every child row points
+      # at a real parent — the integrity guarantee, done by the database.
+      def add_foreign_keys(dropped)
+        dropped.each do |child, column, table|
+          connection.add_foreign_key(child, table, column: column)
+        end
+      end
+```
+
+- [ ] **Step 8: Run the full test file — verify it PASSES**
+
+Run: `bin/rails test test/lib/services/books_migration/id_range_reservation_service_test.rb`
+Expected: PASS (all tests, including the pre-existing users/user_lists ones).
+
+- [ ] **Step 9: Lint and commit**
+
+```bash
+bundle exec standardrb --fix app/lib/services/books_migration.rb app/lib/services/books_migration/id_range_reservation_service.rb test/lib/services/books_migration/id_range_reservation_service_test.rb
+git add app/lib/services/books_migration.rb app/lib/services/books_migration/id_range_reservation_service.rb test/lib/services/books_migration/id_range_reservation_service_test.rb
+git commit -m "Reserve lists ID range for books migration (service + tests)"
+```
+
+---
+
+### Task 2: Migration that applies the reservation
+
+**Files:**
+- Create: `web-app/db/migrate/<timestamp>_reserve_lists_id_range.rb` (via generator)
+- Modify: `web-app/db/schema.rb` (version bump only — no column diff)
+
+**Interfaces:**
+- Consumes: `Services::BooksMigration::IdRangeReservationService.call`.
+- Produces: a migration whose `up` reserves the `lists` range (and no-ops `users`/`user_lists`, already reserved); `down` is intentionally a no-op.
+
+- [ ] **Step 1: Generate the migration file**
+
+Run: `bin/rails generate migration ReserveListsIdRange`
+Expected: creates `db/migrate/<timestamp>_reserve_lists_id_range.rb` (timestamp after `20260701163004`).
+
+- [ ] **Step 2: Replace the migration body**
+
+Replace the generated file's contents with:
+
+```ruby
+class ReserveListsIdRange < ActiveRecord::Migration[8.1]
+  # Reserves the low PK range on the shared `lists` table for the future books
+  # import (preserves original book-list IDs so legacy /lists/:id URLs keep
+  # working). Re-runs Services::BooksMigration::IdRangeReservationService, which
+  # now also relocates existing new-app `lists` rows above the `lists` ceiling,
+  # remaps every column referencing lists.id (incl. the polymorphic
+  # ai_chats.parent), and bumps the lists sequence. `users`/`user_lists` were
+  # reserved by an earlier migration and are a no-op here.
+  # See docs/superpowers/plans/2026-07-03-lists-id-range-reservation.md and
+  # docs/specs/completed/books-migration-01-id-range-reservation.md.
+  #
+  # Idempotent — safe to re-run. db/schema.rb does NOT capture sequence RESTART
+  # values, so db:schema:load starts sequences at 1 again; acceptable because the
+  # reservation only needs to hold where the books import runs (prod + dev).
+  def up
+    result = Services::BooksMigration::IdRangeReservationService.call
+    raise "Lists ID range reservation failed: #{result[:error]}" unless result[:success]
+  end
+
+  def down
+    # Intentionally irreversible: relocating rows and restarting sequences cannot
+    # be cleanly undone. Restore from a snapshot if reversal is ever needed.
+  end
+end
+```
+
+- [ ] **Step 3: Apply the migration to the test DB (updates schema.rb version)**
+
+Run: `RAILS_ENV=test bin/rails db:migrate`
+Expected: migration runs; `db/schema.rb` version line becomes the new timestamp; no column diff.
+
+- [ ] **Step 4: Apply to dev and verify the reserved range is clear**
+
+> Note: this relocates the ~1,484 existing dev music/games lists to `>= 10_000` (and their `ai_chats`/`list_items`/etc.). That is the intended dev setup for the books migration. Snapshot dev first only if you care about its current state.
+
+Run:
+```bash
+bin/rails db:migrate
+bin/rails runner 'puts ActiveRecord::Base.connection.select_value("SELECT COUNT(*) FROM lists WHERE id < 10000")'
+```
+Expected: prints `0` (no lists rows below the ceiling).
+
+- [ ] **Step 5: Verify idempotency (second service run is a no-op)**
+
+Run: `bin/rails runner 'p Services::BooksMigration::IdRangeReservationService.call'`
+Expected: `{:success=>true, :data=>{...}}` and (re-checking) `SELECT COUNT(*) FROM lists WHERE id < 10000` is still `0`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add db/migrate/*_reserve_lists_id_range.rb db/schema.rb
+git commit -m "Add ReserveListsIdRange migration"
+```
+
+---
+
+### Task 3: Document the `lists` reservation
+
+**Files:**
+- Modify: `docs/features/user-lists.md` (Reserved ID Ranges section)
+
+**Interfaces:**
+- Consumes: nothing. Produces: docs reflecting the added `lists` reservation.
+
+- [ ] **Step 1: Add `lists` to the reserved-ranges table and note the collision-safety constraint**
+
+In `docs/features/user-lists.md`, in the "Reserved ID Ranges (Books Migration)" table, add a `lists` row:
+
+```markdown
+| `lists` | `[1, 10_000)` | `>= 10_000` |
+```
+
+Then, immediately after the table, add:
+
+```markdown
+`lists` was reserved in a later migration (`db/migrate/*_reserve_lists_id_range.rb`) so legacy `/lists/:id` URLs keep resolving after import. Its ceiling (`10_000`) must exceed the **new-app** `lists` `MAX(id)` at run time (the relocation is an additive shift, collision-free only when all rows are below the ceiling) — re-confirm before running in production. The reservation also remaps the one **polymorphic** reference to lists, `ai_chats.parent` (`parent_type = 'List'`), which has no FK. See `docs/superpowers/plans/2026-07-03-lists-id-range-reservation.md`.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/features/user-lists.md
+git commit -m "Document lists ID-range reservation"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage** (against the design doc's Phase 0 + this plan's goal):
+- Reserve `lists` range → Task 1 (constants) + Task 2 (migration). ✓
+- Relocate existing new-app list rows + remap FKs → Task 1 `FOREIGN_KEYS["lists"]` (5 columns) + tests. ✓
+- Polymorphic `ai_chats` reference → Task 1 `POLYMORPHIC_FOREIGN_KEYS` + `relocate_polymorphic_rows` + test. ✓
+- No spurious `ranked_lists → lists` FK → Task 1 drop/re-add fix + explicit refute test. ✓
+- Bump `lists` sequence → inherited from `bump_sequences` (iterates `FOREIGN_KEYS.each_key`, now includes `lists`); covered by "next List create ≥ ceiling" test. ✓
+- Idempotent, single transaction → existing service structure + idempotency test. ✓
+- Snapshot-first prod run → Global Constraints + migration comment. ✓
+- Ceiling sizing constraint (must exceed new-app max) → Global Constraints + docs. ✓
+
+**2. Placeholder scan:** No TBD/TODO. All code shown in full. Migration timestamp is produced by the generator (Task 2 Step 1), not hardcoded. ✓
+
+**3. Type consistency:** `IdRangeReservationService.call` returns `{success:, data:/error:}` (unchanged). New constant `POLYMORPHIC_FOREIGN_KEYS` referenced only in `relocate_polymorphic_rows`. Test constant renamed `LISTS_CEILING`→`USER_LISTS_CEILING` with all references updated (Task 1 Step 1); new `LISTS_CEILING` fetches `"lists"`. `foreign_key_exists?`/`add_foreign_key`/`remove_foreign_key` signatures match the existing service usage. ✓

--- a/docs/superpowers/specs/2026-07-03-old-site-data-migration-design.md
+++ b/docs/superpowers/specs/2026-07-03-old-site-data-migration-design.md
@@ -252,6 +252,34 @@ types), `public`, `description`, `position`, `view_mode` (old `nil` → new `def
 | `User.external_provider`, `User.role` | identical ints — direct |
 | `user_lists.view_mode` | old `{default_view:nil, table_view:1, grid_view:2}` → new `{default_view:0,…}` | `nil` → `0` |
 
+## Legacy data volumes (local restore 2026-07-03)
+
+Full prod dump restored locally into `the_greatest_books_legacy` (container `the-greatest-db-1`,
+`localhost:6543`), 0 errors. The `ol_editions`/`ol_works`/`ol_covers` tables are empty (truncated in
+prod long ago). Counts / max-ids that size the phases:
+
+| Table | Rows | max(id) | Note |
+|---|---|---|---|
+| `books` | 126,204 | 141,785 | preserve id; `setval` after |
+| `authors` | 58,193 | 66,839 | preserve id; `setval` after |
+| `book_authors` | 126,869 | — | join |
+| `editions` | 148,296 | — | → `books_editions` |
+| `book_identifiers` | 421,698 | — | → `identifiers` |
+| `categories` | 73,913 | — | fresh id + map |
+| `book_categories` | 1,828,730 | — | → `category_items` (heavy — batch) |
+| `lists` | 1,030 | **1,175** | **Phase 0 reservation ceiling must exceed 1,175 + growth** |
+| `list_items` | 65,252 | — | |
+| `ranking_configurations` | 47 total / **4 active** | — | migrate non-archived only |
+| `ranked_lists` | 17,379 | — | active RCs only |
+| `ranked_books` | 1,853,585 | — | **not migrated** (recomputed) |
+| `list_cons` | 1,869 | — | → penalties (active RCs only) |
+| `list_con_lists` | 48,720 | — | → `list_penalties` (static only) |
+| `users` | 69,459 | 69,498 | reserved ceiling 150k ✓ (~2.15× headroom) |
+| `user_lists` | 282,922 | 604,880 | reserved ceiling 1M ✓ (~1.65× — tight; re-confirm near import) |
+| `user_list_books` | 3,096,597 | — | → `user_list_items` (heaviest — batch) |
+| `links` | 13,404 | — | → `external_links` |
+| `languages` | 201 | — | |
+
 ## Out of scope (no new-site equivalent, or per owner)
 `ai_chats`, `ai_responses`, `goodreads_books`, `goodreads_imports`, `subscriptions`, `reading_goals`,
 `reading_goal_books`, `donations`, `saved_searches`, `recommendation_configs`, `merge_runs`,

--- a/docs/superpowers/specs/2026-07-03-old-site-data-migration-design.md
+++ b/docs/superpowers/specs/2026-07-03-old-site-data-migration-design.md
@@ -1,0 +1,302 @@
+# Old Site → New Site Data Migration — Design
+
+## Status
+- **Status**: Design / brainstorming complete — awaiting review
+- **Created**: 2026-07-03
+- **Owner**: Shane Sherman
+- **Type**: Design doc (seeds per-phase implementation specs)
+
+## Overview
+
+Migrate the public data of the legacy **TheGreatestBooks** app (`the-greatest-books/admin/`,
+Rails 8) into the new multi-domain **The Greatest** app (`web-app/`), transforming the old
+single-purpose schema into the new namespaced/polymorphic/STI object model.
+
+The migration must be **idempotent and re-runnable** (a repeated one-way `old → new` sync until
+cutover), and must **preserve the primary-key IDs** of URL-facing entities so the legacy public
+URLs keep resolving. The old site is entirely **ID-based** (no slugs), so preserving PKs is what
+keeps `/items/:id`, `/books/:id`, `/authors/:id`, `/lists/:id`, `/user_lists/:id` working.
+
+### Goals
+- A per-model **transformation layer** (old row → new attributes) that is unit-testable in isolation.
+- **Idempotent** upserts — rerun any time, converge to the same result.
+- **Preserve IDs** for `books_books`, `books_authors`, `lists`, `users`, `user_lists`.
+- Correct handling of enum re-encodings, polymorphic/STI targets, and FK remapping.
+- Clean decomposition into shippable phases.
+
+### Non-goals
+- Migrating derived/output data that the new app recomputes (`ranked_books` → `ranked_items`).
+- Images (deferred — legacy uses custom S3 keys, new uses ActiveStorage; a separate sub-project).
+- Archived ranking configurations (future: materialized views).
+- Any legacy model with no new-site equivalent (see **Out of scope**).
+- The actual production cutover / DNS / routing swap.
+
+## Background & constraints
+
+- **Topology**: old and new are **separate databases on the same Postgres server**. Postgres cannot
+  join across databases, so the migration runs **inside the new Rails app** with a **second,
+  read-only connection** to the legacy DB. No table-name collisions (distinct databases).
+- **URLs are ID-based**: legacy has no slugs. Preserving PKs = zero-redirect URL continuity. The new
+  models use FriendlyId with `:finders`, so `/books/123` still resolves by ID; fresh slugs are
+  generated during migration.
+- **DB reset before import**: the owner will reset the new DB before the real import, so the target
+  is effectively greenfield at import time. The migration is still designed to be idempotent across
+  reruns (it will be run "constantly" to sync).
+- **Active configs only**: only **non-archived** `ranking_configurations` are migrated, and their
+  penalty `points` are already percentages (0–100) — so they map straight into
+  `PenaltyApplication.value` (validated 0–100) with no clamping.
+- **Search**: the new `SearchIndexable` callbacks queue a `SearchIndexRequest` per write. OpenSearch
+  is not in real use yet, so we **suppress these callbacks during migration** (otherwise millions of
+  request rows) and rely on normal search tooling to index later. No reindex step in this migration.
+
+## Architecture
+
+### Legacy read connection
+- Add a `legacy_books` entry to `config/database.yml` (same host, legacy DB, **read-only** role).
+- Define a minimal, read-only base model `LegacyBooks::Record < ApplicationRecord` (abstract,
+  `connects_to database: { reading: :legacy_books }`), with thin subclasses per legacy table we read
+  (`LegacyBooks::Book`, `LegacyBooks::Author`, …) exposing only the columns/associations we need.
+- Reads are batched (`in_batches` / keyset pagination) to bound memory on large tables.
+
+### Transformation layer (Transformer per model)
+- One **pure** `Transformer` per model under `app/lib/services/books_migration/transformers/`:
+  input = a legacy row (or attribute hash), output = a new-model attributes hash. No DB writes, no
+  side effects → trivially unit-testable with fixtures of real legacy shapes.
+- Transformers own all enum re-encoding, field renames, and value normalization.
+
+### Write path (hybrid)
+- **Through new AR models** for entities needing slugs / validations / normalization
+  (`Books::Author`, `Books::Book`, `Books::Edition`, `List`, `Category`, `RankingConfiguration`,
+  `Penalty`, `UserList`) — via `find_or_initialize_by(id:)` (preserved-PK) or a `legacy_id_map`
+  lookup, assign, `save!`.
+- **`upsert_all`** (raw, fast) for high-volume join/child tables with no meaningful callbacks
+  (`books_book_authors`, `list_items`, `identifiers`, `category_items`, `ranked_lists`,
+  `penalty_applications`, `list_penalties`, `user_list_items`), keyed on their natural unique index.
+- **Search suppression**: wrap each migrator run in a `Services::BooksMigration.without_search_indexing { }`
+  helper (thread-local flag checked by `SearchIndexable#queue_for_indexing`) so bulk writes don't
+  enqueue `SearchIndexRequest` rows.
+- **Counter caches** (`categories.item_count`) are recomputed once at the end rather than per-row.
+
+### Idempotency & `legacy_id_map`
+- **Preserved-PK entities** (`books_books`, `books_authors`, `lists`, `users`, `user_lists`):
+  `new_id == legacy_id`; upsert on `id`. No lookup table needed.
+- **Fresh-PK entities** (`languages`, `categories`, `books_editions`, `ranking_configurations`,
+  `penalties`): a dedicated **`legacy_id_map(model, legacy_id, new_id)`** table (new DB) records the
+  mapping on first insert, reused on reruns and for FK remapping. Keeps domain tables free of
+  `legacy_id` columns.
+- **Join tables**: no mapping needed — matched on their natural composite key once parent IDs resolve.
+
+### Dependency order & orchestration
+A single orchestrator rake task (`data_migration:all`) runs migrators in FK-dependency order; each
+migrator is independently runnable (`data_migration:books`, etc.):
+
+```
+languages → users → authors → books → editions → identifiers
+  → categories → category_items → lists → list_items → external_links
+  → ranking_configurations → ranked_lists → penalties(list_cons)
+  → user_lists → user_list_items
+  → (finalize: recompute counter caches, setval sequences)
+```
+
+### ID preservation strategy
+
+| Table | Keep old IDs? | Mechanism |
+|---|---|---|
+| `books_books`, `books_authors` | **Yes** (book/author URLs) | Books-only tables → insert with explicit `id`, `setval` sequence above legacy max after load. No reservation needed (assumes empty at import; guaranteed by the planned reset). |
+| `lists` | **Yes** (list URLs) | **Phase 0 ID-range reservation** — shared table, music/games occupy low IDs; extend `Services::BooksMigration`. |
+| `users`, `user_lists` | **Yes** | **Already reserved** (`docs/specs/completed/books-migration-01-id-range-reservation.md`) — ceilings `users` 150k, `user_lists` 1M. |
+| `ranking_configurations` | No (`/rc/:id` is low-traffic) | Fresh id + `legacy_id_map`; **active/non-archived only**. |
+| `categories` | No (URLs use slug) | Fresh id, **preserve slug** + `legacy_id_map`. |
+| `books_editions`, join tables, `penalties`, `identifiers`, `external_links`, `user_list_items` | No | Fresh id; match on natural key / `legacy_id_map`. |
+
+> `user_list_items.id` is deliberately **not** reserved (not URL-facing) — fresh ids, `user_list_id`
+> remapped (already preserved).
+
+## Model-by-model mapping
+
+### Reference tables
+- **`languages` → `languages`**: `name` → `name`; generate `slug`; `iso_639_1/3` = nil (legacy has
+  none). Fresh id + map. Match on `name` to avoid dupes across reruns.
+- **`users` → `users`** (preserve id): `auth_uid`, `auth_data`, `email`, `email_verified`,
+  `external_provider` (enum 0–4 identical), `display_name`, `name`, `photo_url`, `provider_data`,
+  `role` (enum 0–2 identical), `sign_in_count`, `last_sign_in_at`, `stripe_customer_id`. Drop
+  `external_provider_uid`, `migrated`, `paid`, `goodreads_import`, etc. (no new columns).
+  **Edge case**: `email` is `uniqueness: true` — on a non-reset rerun, an already-present new-site
+  user with the same email would conflict; the reset makes this moot, but the migrator should match
+  on `id`/`email` and skip re-creating. `after_create :create_default_user_lists` fires → see User lists.
+
+### Authors — `authors` → `books_authors` (preserve id)
+| new | from old |
+|---|---|
+| `name` | `name` |
+| `sort_name` | `family_name` (fallback: `name`) |
+| `birth_year`, `death_year`, `description` | same |
+| `alternate_names` | `alternative_names` (+ merge `alternate_title` style variants if present) |
+| `kind` | default `person` |
+| `slug` | generated (FriendlyId) |
+| — | `ol_author_id` → `Identifier` `books_author_openlibrary_id` |
+Dropped: `gender`, `normalized_name`, `nationality_text`, `calculated_score`, OL cover/photo ids,
+`search_string`, `wikipedia_url` (→ optionally an `external_link` later).
+
+### Books — `books` → `books_books` (preserve id) + `editions` → `books_editions` + identifiers
+| new `books_books` | from old `books` |
+|---|---|
+| `title` | `title` |
+| `subtitle` | `sub_title` |
+| `description` | `description` |
+| `first_published_year` | `first_year_published` |
+| `sort_title` | `sort_title` |
+| `alternate_titles` | `alternate_titles` + `alternate_title_1` |
+| `original_language_id` | remap old `original_language_id` via language `legacy_id_map` |
+| `book_kind` | default `standalone` |
+| `slug` | generated |
+| `default_edition_id` | set after editions load (most-popular edition; synthesize a minimal one if none) |
+Dropped/ignored: `book_type` (use categories instead — owner), `ol_work_id` (**no longer used** —
+owner), `goodreads_id` → `Identifier` `books_work_goodreads_id`, all `ai_*`/`search_string`/`*_image_key`/
+`primary_amazon_url`/`origin_countries`/`series*` (series handled by the new `books_series` model, not
+in this pass).
+
+**`editions` → `books_editions`** (fresh id + map): `book_id` (preserved), `book_binding`
+(**symbol-remap**, see cheatsheet), `publication_year`, `popularity`, `title`, `edition_type` default
+`standard`, `language_id`, `metadata`; `ol_edition_id` → `Identifier` `books_edition_openlibrary_id`;
+`identifiers`/`flat_identifiers` jsonb → `Identifier` rows. `book_versions` is **skipped** in this pass.
+
+**`book_identifiers` → `identifiers`** (polymorphic): edition-level types (ISBN/ASIN/EAN/bookshop)
+attach to the book's (default) edition; work-level types (openlibrary/goodreads/librarything) attach
+to the `Books::Book`. Old `identifier_type` (1..8) is **symbol-remapped** (see cheatsheet); exact
+work-vs-edition placement finalized in Phase 1 with TDD.
+
+### `book_authors` → `books_book_authors` (fresh id, natural key `[book_id, author_id]`)
+`author_id`, `book_id` (both preserved → direct), `position`; new `role` default `0`, `credited_as` nil.
+
+### Categories — `categories` → `categories` (STI `Books::Category`, fresh id + map, **preserve slug**)
+`name`, `slug` (preserve), `category_type` (enum 0–2 identical), `import_source` (enum 0–3 identical),
+`parent_category_id` → `parent_id` (self-referential; resolve via map, two-pass or ordered),
+`deleted`, `description`, `merged_category_names` → `alternative_names`, `book_count` → recomputed
+`item_count`. `type = "Books::Category"`. Dropped: `primary`, `location`, `ai_fix_response`.
+
+**`book_categories` → `category_items`** (natural key `[category_id, item]`): `category_id` (map),
+`item = Books::Book` (preserved id). Skip rows where old `deleted = true`.
+
+### Lists — `lists` → `lists` (STI `Books::List`, preserve id)
+`name`, `description`, `source`, `url`, `year_published`, `number_of_voters`, `submitted_by_id`
+(user preserved), `estimated_quality`, `high_quality_source`, `category_specific`,
+`location_specific`, `yearly_award`, `voter_count_unknown`, `voter_names_unknown`;
+`status` **symbol-remap** (see cheatsheet); `raw_html` → `raw_content`;
+`formatted_text`/`unformatted_text` → `simplified_content`; `books_json` → `items_json`.
+`type = "Books::List"`.
+
+**`list_items` → `list_items`** (natural key `[list_id, listable]`): `list_id` (preserved),
+`listable = Books::Book` (old `book_id`, preserved), `position`, `pending_book_data` → `metadata`,
+`verified` default false. Rows with null `book_id` become pending items (`listable` nil).
+
+### Ranking — `ranking_configurations` (**active/non-archived only**) → STI `Books::RankingConfiguration`
+Fresh id + map. `name`, `description`, `algorithm_version`, `apply_list_dates_penalty`,
+`bonus_pool_percentage`, `exponent`, `global`, `list_limit`, `min_list_weight`, `primary`,
+`primary_mapped_list_cutoff_limit`, `published_at`, `user_id` (preserved);
+`inherit_list_cons` → `inherit_penalties`; `max_age_for_penalty` → `max_list_dates_penalty_age`;
+`max_penalty_percentage` → `max_list_dates_penalty_percentage`;
+`primary_mapped_list_id`/`secondary_mapped_list_id` (list preserved id, direct);
+`inherited_from_id` (map, only if parent is also active). `archived = false`.
+Dropped: `starting_score`, `min_max_normalization`, `list_cons_are_percentages`,
+`apply_global_age_penalty`.
+
+**`ranked_lists` → `ranked_lists`** (natural key `[list_id, ranking_configuration_id]`, active RCs
+only): `list_id` (preserved), `ranking_configuration_id` (map), `weight`.
+
+**`ranked_books` → NOT migrated** — recomputed by the new ranking system after load.
+
+### Penalties — `list_cons` + `list_con_lists` → `penalties` + `penalty_applications` + `list_penalties`
+The old model attaches a penalty (`list_con`) to a **ranking_configuration** with `points`; the new
+model splits definition / per-config application / per-list attachment across three tables. Only
+penalties belonging to **active** ranking configs are migrated.
+
+- Each old `list_con` →
+  - `Penalty` (`type = "Books::Penalty"`, `name`, `description`, `dynamic_type` copied directly —
+    old enum 0–4 is a subset of the new enum with **identical integer values**), fresh id + map;
+  - `PenaltyApplication` (`penalty_id` = mapped, `ranking_configuration_id` = mapped config,
+    `value` = old `points`; already 0–100 for active configs).
+- **Static** `list_con` (`dynamic_type` nil) only: each `list_con_list` → a `ListPenalty`
+  (`list_id` = the `ranked_list`'s `list_id`, `penalty_id` = mapped). Natural key `[list_id, penalty_id]`.
+- **Dynamic** `list_con` (`dynamic_type` set): **no** `ListPenalty` rows — the new model forbids
+  attaching dynamic penalties to lists (`ListPenalty#penalty_must_be_static`); they apply per-config.
+
+### User lists — `user_lists` → `user_lists` (STI `Books::UserList`, preserve id) + items
+**Prerequisite**: create `Books::UserList < UserList` (thin STI subclass mirroring
+`Music::*/Games::UserList`) defining `default_list_types` for `read/reading/want_to_read/favorite/custom`
+and name/icon/`completed_on` behavior.
+
+`user_lists` → `user_lists`: `user_id` (preserved), `name`, `list_type` (enum 0–4 → `Books::UserList`
+types), `public`, `description`, `position`, `view_mode` (old `nil` → new `default_view`/0).
+`type = "Books::UserList"`. Dedup the 4 system lists against those auto-created by
+`User#create_default_user_lists` (match by `list_type`); custom lists insert fresh with preserved id.
+
+**`user_list_books` → `user_list_items`** (fresh id, natural key `[user_list_id, listable]`):
+`user_list_id` (preserved), `listable = Books::Book` (preserved), `position`, `read_date` →
+`completed_on`.
+
+### External links — `links` → `external_links` (polymorphic parent)
+`parent = Books::Book` (preserved), `url`, `name`, `description`, `submitted_by_id` → `submitted_by`
+(user preserved); `source` inferred from URL host (default `other`), `link_category` default,
+`public` true. Fresh id, natural key `[parent, url]`.
+
+### Enum re-encoding cheatsheet (the landmines — raw integer copy would corrupt data)
+| Field | Old → New | Note |
+|---|---|---|
+| `List.status` | old `{unapproved:0, approved:1, active:2, rejected:3, inactive:4, pending:5}` → new `{unapproved:0, approved:1, rejected:2, active:3}` | **map by symbol**; `active`/`rejected` swap ints; `inactive`,`pending` → `unapproved` |
+| `Edition.book_binding` | old `{paperback:0, hardcover:1, ebook:2, audible:3, mass_market_paperback:4, audio:5, library_binding:6, collectable:7, leather_bound:8, other:9}` → new `{hardcover:0, paperback:1, mass_market:2, ebook:3, audiobook:4, library_binding:5, leather_bound:6, other:7}` | **map by symbol**; `audible`+`audio` → `audiobook`; `collectable` → `other` |
+| `book_identifiers.identifier_type` | old `{isbn10:1, isbn13:2, asin:3, ean13:4, goodreads_id:5, librarything_id:6, openlibrary_id:7, bookshop_org_id:8}` → new `Identifier` `books_edition_*` / `books_work_*` | **map by symbol** + work/edition placement |
+| `Category.category_type` | `{genre:0, location:1, subject:2}` | identical ints (new has more) — direct |
+| `Category.import_source` | `{amazon:0, open_library:1, openai:2, goodreads:3}` | identical ints — direct |
+| `list_cons.dynamic_type` → `Penalty.dynamic_type` | `{number_of_voters:0 … category_specific:4}` | new enum is a superset; **ints 0–4 identical** — direct |
+| `User.external_provider`, `User.role` | identical ints — direct |
+| `user_lists.view_mode` | old `{default_view:nil, table_view:1, grid_view:2}` → new `{default_view:0,…}` | `nil` → `0` |
+
+## Out of scope (no new-site equivalent, or per owner)
+`ai_chats`, `ai_responses`, `goodreads_books`, `goodreads_imports`, `subscriptions`, `reading_goals`,
+`reading_goal_books`, `donations`, `saved_searches`, `recommendation_configs`, `merge_runs`,
+`merge_results`, `blogs`, `blog_posts`, `comments`, `reviews`, `sellers`, `sales`,
+`bookshop_search_results`, `changesets`, `csv_exports`, `deleted_categories`, `webhook_events`,
+`versions` (PaperTrail), `ol_editions`/`ol_works`/`ol_covers`, `pending_list_items`, `nationalities`/
+`author_nationalities`/`countries`/`book_countries` (no model yet), `book_versions`, `book_type`,
+`ranked_books`, **images** (deferred), **archived ranking_configurations** (future: materialized views).
+
+## Phasing / decomposition
+
+Each phase gets its own implementation spec (`docs/specs/`) + plan.
+
+- **Phase 0 — `lists` ID-range reservation** *(urgent / time-sensitive)*
+  Extend `Services::BooksMigration` (`RESERVED_CEILINGS`, `FOREIGN_KEYS`) to cover `lists`: bump the
+  `lists` sequence above a reserved ceiling and relocate existing music/games/movies list rows (with
+  FK remap for `list_items.list_id`, `ranked_lists.list_id`, `list_penalties.list_id`,
+  `ranking_configurations.primary_mapped_list_id`/`secondary_mapped_list_id`, etc.) into the high
+  range. Mirrors the completed `users`/`user_lists` reservation. Must run while music/games list data
+  is still small. Confirm legacy `lists MAX(id)` near import time to size the ceiling.
+
+- **Phase 1 — ETL framework + core entities**
+  Legacy connection + `LegacyBooks::` models; `legacy_id_map`; `Transformer`/`Migrator` base classes;
+  orchestrator rake task; search-callback suppression + counter-cache/sequence finalize step.
+  Migrators: languages, users, authors, books, editions, identifiers, book_authors, categories,
+  category_items, external_links.
+
+- **Phase 2 — lists & rankings**
+  lists, list_items, ranking_configurations (active only), ranked_lists, penalties
+  (`list_cons`→penalties/penalty_applications/list_penalties).
+
+- **Phase 3 — user data**
+  `Books::UserList` STI subclass (prerequisite) + user_lists, user_list_books → user_list_items.
+
+## Open questions / future
+- **Identifier placement** (work vs edition) for a few legacy `book_identifiers` types — finalized in
+  Phase 1 via TDD against real legacy rows.
+- **`List.status` fallbacks** — `inactive`/`pending` → `unapproved` (assumed; confirm against data).
+- **Deletes** — not propagated in any phase (owner confirmed). A reconciliation sweep can be added
+  later if a true mirror is ever needed.
+- **Images**, **archived RCs**, **series**, **multi-book groupings** — separate future sub-projects.
+
+## References
+- Completed reservation spec: `docs/specs/completed/books-migration-01-id-range-reservation.md`
+- Reusable service: `app/lib/services/books_migration.rb` (`RESERVED_CEILINGS`, `FOREIGN_KEYS`)
+- New schema: `web-app/db/schema.rb`; Legacy schema: `the-greatest-books/admin/db/schema.rb`
+- Legacy issues context: `docs/issues_with_old_site.md`
+- New object model: `docs/superpowers/specs/2026-06-29-books-object-model-design.md`

--- a/web-app/app/lib/services/books_migration.rb
+++ b/web-app/app/lib/services/books_migration.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 module Services
-  # Reserves the low primary-key ID range on `users` and `user_lists` for the
-  # future Greatest Books migration. Books rows are imported preserving their
-  # original auto-increment IDs in `[1, ceiling)`; every new-app row lives at
-  # `>= ceiling`. See docs/specs/completed/books-migration-01-id-range-reservation.md.
+  # Reserves the low primary-key ID range on `users`, `user_lists`, and `lists`
+  # for the future Greatest Books migration. Books rows are imported preserving
+  # their original auto-increment IDs in `[1, ceiling)`; every new-app row lives
+  # at `>= ceiling`. See docs/specs/completed/books-migration-01-id-range-reservation.md.
   module BooksMigration
     # Per-table reserved ceilings: books rows keep their original IDs below the
     # ceiling; new-app rows are relocated to and minted at `>= ceiling`. Sized
@@ -14,7 +14,8 @@ module Services
     # and raise a ceiling if needed (cost is zero on a bigint PK).
     RESERVED_CEILINGS = {
       "users" => 150_000,
-      "user_lists" => 1_000_000
+      "user_lists" => 1_000_000,
+      "lists" => 10_000
     }.freeze
 
     # Reserved table => the FK columns that must be remapped when one of its rows
@@ -27,6 +28,9 @@ module Services
     #                   penalties.user_id, ranking_configurations.user_id,
     #                   user_lists.user_id
     #   "user_lists" <- user_list_items.user_list_id
+    #   "lists"      <- list_items.list_id, list_penalties.list_id,
+    #                   ranked_lists.list_id, ranking_configurations.primary_mapped_list_id,
+    #                   ranking_configurations.secondary_mapped_list_id
     FOREIGN_KEYS = {
       "users" => [
         ["ai_chats", "user_id"],
@@ -39,6 +43,22 @@ module Services
       ],
       "user_lists" => [
         ["user_list_items", "user_list_id"]
+      ],
+      "lists" => [
+        ["list_items", "list_id"],
+        ["list_penalties", "list_id"],
+        ["ranked_lists", "list_id"],
+        ["ranking_configurations", "primary_mapped_list_id"],
+        ["ranking_configurations", "secondary_mapped_list_id"]
+      ]
+    }.freeze
+
+    # Polymorphic references have no DB FK. Rails stores the STI *base* class
+    # name in the `_type` column, so every list's ai_chat is `parent_type = "List"`.
+    # Format: [child_table, id_column, type_column, type_value].
+    POLYMORPHIC_FOREIGN_KEYS = {
+      "lists" => [
+        ["ai_chats", "parent_id", "parent_type", "List"]
       ]
     }.freeze
   end

--- a/web-app/app/lib/services/books_migration.rb
+++ b/web-app/app/lib/services/books_migration.rb
@@ -20,7 +20,7 @@ module Services
 
     # Reserved table => the FK columns that must be remapped when one of its rows
     # is relocated out of the reserved range. Verified against db/schema.rb
-    # (version 2026_04_22_040533). Any FK added before this migration ships must
+    # (version 2026_07_03_190903). Any FK added before this migration ships must
     # be added here.
     #
     #   "users"      <- ai_chats.user_id, domain_roles.user_id,

--- a/web-app/app/lib/services/books_migration/id_range_reservation_service.rb
+++ b/web-app/app/lib/services/books_migration/id_range_reservation_service.rb
@@ -24,9 +24,10 @@ module Services
 
       def call
         ActiveRecord::Base.transaction do
-          drop_foreign_keys
+          dropped = drop_foreign_keys
           relocate_rows
-          add_foreign_keys
+          relocate_polymorphic_rows
+          add_foreign_keys(dropped)
           bump_sequences
         end
         success({ceilings: RESERVED_CEILINGS})
@@ -61,21 +62,39 @@ module Services
         end
       end
 
-      def drop_foreign_keys
-        each_foreign_key do |child, column, table|
-          if connection.foreign_key_exists?(child, table, column: column)
-            connection.remove_foreign_key(child, table, column: column)
+      # Polymorphic references have no FK to drop/re-add; shift the id column for
+      # rows whose *_type matches the reserved table, by that table's ceiling.
+      def relocate_polymorphic_rows
+        POLYMORPHIC_FOREIGN_KEYS.each do |table, refs|
+          ceiling = RESERVED_CEILINGS.fetch(table)
+          refs.each do |child, id_column, type_column, type_value|
+            connection.execute(
+              "UPDATE #{child} SET #{id_column} = #{id_column} + #{ceiling} " \
+              "WHERE #{type_column} = #{connection.quote(type_value)} AND #{id_column} < #{ceiling}"
+            )
           end
         end
       end
 
+      # Returns the FKs it actually dropped, so add_foreign_keys re-adds only
+      # those — a column in FOREIGN_KEYS without a real DB FK (ranked_lists.list_id)
+      # is shifted but must NOT gain a new FK.
+      def drop_foreign_keys
+        dropped = []
+        each_foreign_key do |child, column, table|
+          if connection.foreign_key_exists?(child, table, column: column)
+            connection.remove_foreign_key(child, table, column: column)
+            dropped << [child, column, table]
+          end
+        end
+        dropped
+      end
+
       # Re-adding a validated FK forces Postgres to verify every child row points
       # at a real parent — the integrity guarantee, done by the database.
-      def add_foreign_keys
-        each_foreign_key do |child, column, table|
-          unless connection.foreign_key_exists?(child, table, column: column)
-            connection.add_foreign_key(child, table, column: column)
-          end
+      def add_foreign_keys(dropped)
+        dropped.each do |child, column, table|
+          connection.add_foreign_key(child, table, column: column)
         end
       end
 

--- a/web-app/db/migrate/20260703190903_reserve_lists_id_range.rb
+++ b/web-app/db/migrate/20260703190903_reserve_lists_id_range.rb
@@ -19,6 +19,10 @@ class ReserveListsIdRange < ActiveRecord::Migration[8.1]
 
   def down
     # Intentionally irreversible: relocating rows and restarting sequences cannot
-    # be cleanly undone. Restore from a snapshot if reversal is ever needed.
+    # be cleanly undone. Raising (rather than a silent no-op) stops db:rollback
+    # from marking this version reverted while the DB stays in the reserved
+    # state — which would let a later db:migrate re-run `up` and, post-import,
+    # relocate the preserved book-list IDs. Restore from a snapshot to reverse.
+    raise ActiveRecord::IrreversibleMigration
   end
 end

--- a/web-app/db/migrate/20260703190903_reserve_lists_id_range.rb
+++ b/web-app/db/migrate/20260703190903_reserve_lists_id_range.rb
@@ -1,0 +1,24 @@
+class ReserveListsIdRange < ActiveRecord::Migration[8.1]
+  # Reserves the low PK range on the shared `lists` table for the future books
+  # import (preserves original book-list IDs so legacy /lists/:id URLs keep
+  # working). Re-runs Services::BooksMigration::IdRangeReservationService, which
+  # now also relocates existing new-app `lists` rows above the `lists` ceiling,
+  # remaps every column referencing lists.id (incl. the polymorphic
+  # ai_chats.parent), and bumps the lists sequence. `users`/`user_lists` were
+  # reserved by an earlier migration and are a no-op here.
+  # See docs/superpowers/plans/2026-07-03-lists-id-range-reservation.md and
+  # docs/specs/completed/books-migration-01-id-range-reservation.md.
+  #
+  # Idempotent — safe to re-run. db/schema.rb does NOT capture sequence RESTART
+  # values, so db:schema:load starts sequences at 1 again; acceptable because the
+  # reservation only needs to hold where the books import runs (prod + dev).
+  def up
+    result = Services::BooksMigration::IdRangeReservationService.call
+    raise "Lists ID range reservation failed: #{result[:error]}" unless result[:success]
+  end
+
+  def down
+    # Intentionally irreversible: relocating rows and restarting sequences cannot
+    # be cleanly undone. Restore from a snapshot if reversal is ever needed.
+  end
+end

--- a/web-app/db/migrate/20260704014923_drop_stray_ranked_lists_list_foreign_key.rb
+++ b/web-app/db/migrate/20260704014923_drop_stray_ranked_lists_list_foreign_key.rb
@@ -1,0 +1,20 @@
+class DropStrayRankedListsListForeignKey < ActiveRecord::Migration[8.1]
+  # `20250710152255_create_ranked_lists` created a `ranked_lists.list_id -> lists`
+  # FK via `t.references :list, foreign_key: true`, and no later migration removed
+  # it. Yet that FK is absent from db/schema.rb and from every live database
+  # (dev/prod restore, CI schema:load) — it was dropped somewhere in the real DB
+  # lineage, and schema.rb was dumped from that state. So only a fresh
+  # `rails db:migrate` from zero would re-create it, diverging from schema.rb.
+  #
+  # Formalize the drop so a from-scratch migrate matches schema.rb (no FK). This
+  # keeps `ranked_lists.list_id` intentionally FK-less (it's remapped shift-only by
+  # Services::BooksMigration during the lists ID-range reservation). Idempotent via
+  # if_exists — a no-op in every environment that already lacks the FK.
+  def up
+    remove_foreign_key :ranked_lists, :lists, column: :list_id, if_exists: true
+  end
+
+  def down
+    add_foreign_key :ranked_lists, :lists, column: :list_id, if_not_exists: true
+  end
+end

--- a/web-app/db/schema.rb
+++ b/web-app/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_01_163004) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_03_190903) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 

--- a/web-app/db/schema.rb
+++ b/web-app/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_03_190903) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_04_014923) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 

--- a/web-app/test/lib/services/books_migration/id_range_reservation_service_test.rb
+++ b/web-app/test/lib/services/books_migration/id_range_reservation_service_test.rb
@@ -2,7 +2,8 @@ require "test_helper"
 
 class Services::BooksMigration::IdRangeReservationServiceTest < ActiveSupport::TestCase
   USERS_CEILING = Services::BooksMigration::RESERVED_CEILINGS.fetch("users")
-  LISTS_CEILING = Services::BooksMigration::RESERVED_CEILINGS.fetch("user_lists")
+  USER_LISTS_CEILING = Services::BooksMigration::RESERVED_CEILINGS.fetch("user_lists")
+  LISTS_CEILING = Services::BooksMigration::RESERVED_CEILINGS.fetch("lists")
 
   # Controlled low-id rows seeded into the reserved range. Fixtures use hashed
   # (pseudo-random) ids, so we insert known ids via raw SQL to assert relocation
@@ -11,6 +12,12 @@ class Services::BooksMigration::IdRangeReservationServiceTest < ActiveSupport::T
   RESERVED_LIST_ID = 7
   RESERVED_ITEM_ID = 9
   RESERVED_OTHER_LIST_ID = 11
+  RESERVED_LIST_ITEM_ID = 21
+  RESERVED_RC_ID = 31
+  RESERVED_RANKED_LIST_ID = 41
+  RESERVED_PENALTY_ID = 51
+  RESERVED_LIST_PENALTY_ID = 61
+  RESERVED_AI_CHAT_ID = 71
 
   setup do
     @conn = ActiveRecord::Base.connection
@@ -23,18 +30,18 @@ class Services::BooksMigration::IdRangeReservationServiceTest < ActiveSupport::T
 
     # PKs shifted by their own table's ceiling.
     assert_equal RESERVED_USER_ID + USERS_CEILING, relocated_id("users", RESERVED_USER_ID)
-    assert_equal RESERVED_LIST_ID + LISTS_CEILING, relocated_id("user_lists", RESERVED_LIST_ID)
+    assert_equal RESERVED_LIST_ID + USER_LISTS_CEILING, relocated_id("user_lists", RESERVED_LIST_ID)
 
     # user_lists.user_id -> users remapped to the relocated parent (users ceiling).
     assert_equal RESERVED_USER_ID + USERS_CEILING,
-      @conn.select_value("SELECT user_id FROM user_lists WHERE id = #{RESERVED_LIST_ID + LISTS_CEILING}").to_i
+      @conn.select_value("SELECT user_id FROM user_lists WHERE id = #{RESERVED_LIST_ID + USER_LISTS_CEILING}").to_i
 
-    # lists.submitted_by_id -> users remapped (users ceiling).
+    # lists.submitted_by_id -> users remapped (users ceiling); the lists row itself relocated by LISTS_CEILING.
     assert_equal RESERVED_USER_ID + USERS_CEILING,
-      @conn.select_value("SELECT submitted_by_id FROM lists WHERE id = #{RESERVED_OTHER_LIST_ID}").to_i
+      @conn.select_value("SELECT submitted_by_id FROM lists WHERE id = #{RESERVED_OTHER_LIST_ID + LISTS_CEILING}").to_i
 
     # user_list_items.user_list_id -> user_lists remapped (user_lists ceiling; FK integrity: parent exists).
-    assert_equal RESERVED_LIST_ID + LISTS_CEILING,
+    assert_equal RESERVED_LIST_ID + USER_LISTS_CEILING,
       @conn.select_value("SELECT user_list_id FROM user_list_items WHERE id = #{RESERVED_ITEM_ID}").to_i
   end
 
@@ -42,7 +49,7 @@ class Services::BooksMigration::IdRangeReservationServiceTest < ActiveSupport::T
     Services::BooksMigration::IdRangeReservationService.call
 
     assert_equal 0, @conn.select_value("SELECT COUNT(*) FROM users WHERE id < #{USERS_CEILING}").to_i
-    assert_equal 0, @conn.select_value("SELECT COUNT(*) FROM user_lists WHERE id < #{LISTS_CEILING}").to_i
+    assert_equal 0, @conn.select_value("SELECT COUNT(*) FROM user_lists WHERE id < #{USER_LISTS_CEILING}").to_i
   end
 
   test "next User and UserList creates land at or above the ceiling" do
@@ -52,7 +59,7 @@ class Services::BooksMigration::IdRangeReservationServiceTest < ActiveSupport::T
     assert_operator user.id, :>=, USERS_CEILING
 
     list = Games::UserList.create!(name: "Post Migration", list_type: :custom, user: user)
-    assert_operator list.id, :>=, LISTS_CEILING
+    assert_operator list.id, :>=, USER_LISTS_CEILING
   end
 
   test "is idempotent: a second run is a no-op and does not error" do
@@ -85,6 +92,75 @@ class Services::BooksMigration::IdRangeReservationServiceTest < ActiveSupport::T
     assert UserList.exists?(42), "book row at reserved id 42 should be findable"
   end
 
+  test "relocates lists and remaps every column that references lists.id" do
+    result = Services::BooksMigration::IdRangeReservationService.call
+    assert result[:success], "service should succeed: #{result[:error]}"
+
+    relocated = RESERVED_OTHER_LIST_ID + LISTS_CEILING
+
+    assert_equal relocated, relocated_id("lists", RESERVED_OTHER_LIST_ID)
+    assert_equal relocated,
+      @conn.select_value("SELECT list_id FROM list_items WHERE id = #{RESERVED_LIST_ITEM_ID}").to_i
+    assert_equal relocated,
+      @conn.select_value("SELECT list_id FROM ranked_lists WHERE id = #{RESERVED_RANKED_LIST_ID}").to_i
+    assert_equal relocated,
+      @conn.select_value("SELECT list_id FROM list_penalties WHERE id = #{RESERVED_LIST_PENALTY_ID}").to_i
+    assert_equal relocated,
+      @conn.select_value("SELECT primary_mapped_list_id FROM ranking_configurations WHERE id = #{RESERVED_RC_ID}").to_i
+    assert_equal relocated,
+      @conn.select_value("SELECT secondary_mapped_list_id FROM ranking_configurations WHERE id = #{RESERVED_RC_ID}").to_i
+  end
+
+  test "remaps the polymorphic ai_chats reference to a relocated list" do
+    Services::BooksMigration::IdRangeReservationService.call
+
+    assert_equal RESERVED_OTHER_LIST_ID + LISTS_CEILING,
+      @conn.select_value("SELECT parent_id FROM ai_chats WHERE id = #{RESERVED_AI_CHAT_ID}").to_i
+  end
+
+  test "does not create a foreign key for the FK-less ranked_lists.list_id" do
+    refute @conn.foreign_key_exists?("ranked_lists", "lists", column: "list_id"),
+      "precondition: ranked_lists.list_id must have no FK"
+
+    Services::BooksMigration::IdRangeReservationService.call
+
+    refute @conn.foreign_key_exists?("ranked_lists", "lists", column: "list_id"),
+      "reservation must not add a ranked_lists -> lists FK"
+  end
+
+  test "leaves no lists rows below the lists ceiling" do
+    Services::BooksMigration::IdRangeReservationService.call
+
+    assert_equal 0, @conn.select_value("SELECT COUNT(*) FROM lists WHERE id < #{LISTS_CEILING}").to_i
+  end
+
+  test "next List create lands at or above the lists ceiling" do
+    Services::BooksMigration::IdRangeReservationService.call
+
+    list = Books::List.create!(name: "Post-reservation List")
+    assert_operator list.id, :>=, LISTS_CEILING
+  end
+
+  test "is idempotent for lists: a second run does not shift the list again" do
+    assert Services::BooksMigration::IdRangeReservationService.call[:success]
+    relocated = relocated_id("lists", RESERVED_OTHER_LIST_ID)
+
+    assert Services::BooksMigration::IdRangeReservationService.call[:success]
+    assert_equal relocated, relocated_id("lists", RESERVED_OTHER_LIST_ID)
+  end
+
+  test "a simulated book-list import at a low reserved id succeeds without collision" do
+    Services::BooksMigration::IdRangeReservationService.call
+
+    @conn.execute(<<~SQL)
+      INSERT INTO lists (id, type, name, status, estimated_quality, created_at, updated_at)
+      VALUES (42, 'Books::List', 'Imported Book List', 0, 0, now(), now())
+    SQL
+
+    assert_equal 42, @conn.select_value("SELECT id FROM lists WHERE id = 42").to_i
+    assert List.exists?(42), "book list at reserved id 42 should be findable"
+  end
+
   private
 
   # `id + ceiling` for a row originally seeded at `original_id`, or nil if absent.
@@ -111,6 +187,32 @@ class Services::BooksMigration::IdRangeReservationServiceTest < ActiveSupport::T
     @conn.execute(<<~SQL)
       INSERT INTO lists (id, type, name, submitted_by_id, status, estimated_quality, created_at, updated_at)
       VALUES (#{RESERVED_OTHER_LIST_ID}, 'Games::List', 'Reserved Source List', #{RESERVED_USER_ID}, 0, 0, now(), now())
+    SQL
+    @conn.execute(<<~SQL)
+      INSERT INTO list_items (id, list_id, verified, created_at, updated_at)
+      VALUES (#{RESERVED_LIST_ITEM_ID}, #{RESERVED_OTHER_LIST_ID}, false, now(), now())
+    SQL
+    @conn.execute(<<~SQL)
+      INSERT INTO ranking_configurations
+        (id, type, name, primary_mapped_list_id, secondary_mapped_list_id, created_at, updated_at)
+      VALUES (#{RESERVED_RC_ID}, 'Games::RankingConfiguration', 'Reserved RC',
+              #{RESERVED_OTHER_LIST_ID}, #{RESERVED_OTHER_LIST_ID}, now(), now())
+    SQL
+    @conn.execute(<<~SQL)
+      INSERT INTO ranked_lists (id, list_id, ranking_configuration_id, created_at, updated_at)
+      VALUES (#{RESERVED_RANKED_LIST_ID}, #{RESERVED_OTHER_LIST_ID}, #{RESERVED_RC_ID}, now(), now())
+    SQL
+    @conn.execute(<<~SQL)
+      INSERT INTO penalties (id, type, name, created_at, updated_at)
+      VALUES (#{RESERVED_PENALTY_ID}, 'Global::Penalty', 'Reserved Penalty', now(), now())
+    SQL
+    @conn.execute(<<~SQL)
+      INSERT INTO list_penalties (id, list_id, penalty_id, created_at, updated_at)
+      VALUES (#{RESERVED_LIST_PENALTY_ID}, #{RESERVED_OTHER_LIST_ID}, #{RESERVED_PENALTY_ID}, now(), now())
+    SQL
+    @conn.execute(<<~SQL)
+      INSERT INTO ai_chats (id, model, parent_type, parent_id, created_at, updated_at)
+      VALUES (#{RESERVED_AI_CHAT_ID}, 'test-model', 'List', #{RESERVED_OTHER_LIST_ID}, now(), now())
     SQL
   end
 end

--- a/web-app/test/lib/services/books_migration/id_range_reservation_service_test.rb
+++ b/web-app/test/lib/services/books_migration/id_range_reservation_service_test.rb
@@ -128,6 +128,15 @@ class Services::BooksMigration::IdRangeReservationServiceTest < ActiveSupport::T
       "reservation must not add a ranked_lists -> lists FK"
   end
 
+  test "re-adds the real lists foreign keys after relocation" do
+    Services::BooksMigration::IdRangeReservationService.call
+
+    assert @conn.foreign_key_exists?("list_items", "lists", column: "list_id")
+    assert @conn.foreign_key_exists?("list_penalties", "lists", column: "list_id")
+    assert @conn.foreign_key_exists?("ranking_configurations", "lists", column: "primary_mapped_list_id")
+    assert @conn.foreign_key_exists?("ranking_configurations", "lists", column: "secondary_mapped_list_id")
+  end
+
   test "leaves no lists rows below the lists ceiling" do
     Services::BooksMigration::IdRangeReservationService.call
 


### PR DESCRIPTION
## Phase 0: `lists` ID-range reservation

First step of migrating legacy TheGreatestBooks data into the new app. The old site is entirely **ID-based** (no slugs), so legacy public URLs (`/lists/:id`) only keep working if book lists are imported with their **original primary keys preserved**. This PR reserves the low ID range on the shared `lists` table so that's collision-free — the same mechanism already applied to `users`/`user_lists` (see `docs/specs/completed/books-migration-01-id-range-reservation.md`).

It also lands the **overarching migration design doc** and this phase's **implementation plan** (planning artifacts; Phases 1–3 are future work).

### What it does
Extends the generic `Services::BooksMigration` reservation (ceiling **10,000** for `lists`) to, in one transaction:
- relocate existing new-app `lists` rows (music/games/movies) up to `>= 10_000`, remapping **every** column referencing `lists.id`:
  - FK columns: `list_items.list_id`, `list_penalties.list_id`, `ranking_configurations.primary_mapped_list_id`, `ranking_configurations.secondary_mapped_list_id`
  - `ranked_lists.list_id` — has **no** DB FK, so it's shift-only (and the service was fixed to re-add only the FKs it actually dropped, so it never invents a `ranked_lists → lists` FK)
  - the polymorphic `ai_chats.parent` (`parent_type = 'List'`) — no FK; new `POLYMORPHIC_FOREIGN_KEYS` handling
- bump the `lists` sequence above the ceiling so all future rows land in the high range.

Idempotent (a second run is a no-op), single transaction, irreversible `down` (snapshot-first in prod).

### Why 10,000
The relocation is an additive `id + ceiling` shift, collision-free only when every existing row is below the ceiling. Dev `lists` max id is ~1,475 and legacy is 1,175, so 10,000 is comfortable. It fails **safe**: if the ceiling is ever ≤ `MAX(id)` at run time, a PK collision rolls the transaction back and the migration raises.

> **⚠️ Runbook gate:** before running in production, confirm `SELECT max(id) FROM lists` (new-app prod) is well under `10_000`; raise the ceiling if not (zero cost on a bigint PK). Snapshot first.

### Testing
- New/expanded service tests assert real post-relocation DB state for all 5 FK/shift columns, the polymorphic `ai_chats` case, that the 4 real FKs are re-added, that no `ranked_lists → lists` FK is created, idempotency, "no rows below ceiling", next-create ≥ ceiling, and a simulated low-id book-list import. Focused suite: 13 runs / 37 assertions / 0 failures.
- Full suite: 4315 runs, 0 failures. `standardrb` clean.
- Migration applied to dev + test; `lists < 10000` count = 0; re-run confirmed no-op.

### Notes
- Brakeman flags the raw-SQL shift in `relocate_polymorphic_rows` as possible SQL injection — a **false positive** (interpolated values are hardcoded constants; the type value is `connection.quote`d), identical to the pre-existing pattern already merged in the same service. Left unsuppressed to match existing convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
