### PR TITLE
Data migration: books editions migrator (+ publisher_name)

### DIFF
--- a/docs/superpowers/plans/2026-07-04-books-editions-migration.md
+++ b/docs/superpowers/plans/2026-07-04-books-editions-migration.md
@@ -448,9 +448,13 @@ First, proactively scan for orphaned edition `book_id`s (a legacy edition whose 
 
 ```bash
 bin/rails runner '
+# Legacy editions and primary books_books live in SEPARATE databases, so this
+# must be TWO queries diffed in Ruby (no cross-DB subquery).
 klass = Class.new(LegacyBooks::Record) { self.table_name = "editions" }
-orphans = klass.where.not(book_id: nil).where.not(book_id: Books::Book.select(:id)).count
-puts "orphan_edition_book_ids=#{orphans}"'
+legacy_book_ids = klass.where.not(book_id: nil).distinct.pluck(:book_id)
+existing = Books::Book.where(id: legacy_book_ids).pluck(:id).to_set
+orphans = legacy_book_ids.reject { |bid| existing.include?(bid) }
+puts "orphan_edition_book_ids=#{orphans.size}"'
 ```
 Expected: `orphan_edition_book_ids=0`. If non-zero, report the ids — the run will name the first offending edition, and it is idempotent/resumable.
 

--- a/docs/superpowers/plans/2026-07-04-books-editions-migration.md
+++ b/docs/superpowers/plans/2026-07-04-books-editions-migration.md
@@ -2,9 +2,9 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Migrate legacy `editions` → `books_editions` (fresh id + `LegacyIdMap`, `book_binding` re-encoded by symbol) and set `default_edition_id` on the already-migrated books, on top of the Phase 1a/1b ETL framework.
+**Goal:** Migrate legacy `editions` → `books_editions` (fresh id + `LegacyIdMap`, `book_binding` re-encoded by symbol, `publisher_name` extracted from the Amazon metadata) and set `default_edition_id` on the already-migrated books, on top of the Phase 1a/1b ETL framework.
 
-**Architecture:** One more `Services::BooksMigration::Migrator` subclass reusing the base (batched read → pure `EditionTransformer` → idempotent upsert through the real `Books::Edition`, search suppressed). Editions take fresh auto ids; the `LegacyIdMap("Books::Edition")` is the dedup key (needed later by identifiers). `default_edition_id` is set in `finalize` by one set-based `UPDATE` (most-popular edition per book; editionless books stay NULL — no synthesis).
+**Architecture:** One more `Services::BooksMigration::Migrator` subclass reusing the base (batched read → pure `EditionTransformer` → idempotent upsert through the real `Books::Edition`, search suppressed). Editions take fresh auto ids; the `LegacyIdMap("Books::Edition")` is the dedup key (needed later by identifiers). A new `publisher_name` column captures the publisher pulled from the legacy Amazon metadata blob. `default_edition_id` is set in `finalize` by one set-based `UPDATE` (most-popular edition per book; editionless books stay NULL — no synthesis).
 
 **Tech Stack:** Rails 8.1, PostgreSQL 17, Minitest + Mocha + fixtures, `Services::` migrators.
 
@@ -13,12 +13,13 @@
 ## Global Constraints
 
 - Run all commands from `/home/shane/dev/the-greatest/web-app`.
-- Lint with `bundle exec standardrb` (NOT rubocop). Tests: `bin/rails test`.
-- Legacy dev DB `the_greatest_books_legacy` on `localhost:6543`. Volume: `editions` 148,296; 38,668 of 126,204 books have ≥1 edition.
+- Lint with `bundle exec standardrb` (NOT rubocop). Tests: `bin/rails test`. Use Rails generators for the migration (never hand-create).
+- Legacy dev DB `the_greatest_books_legacy` on `localhost:6543`. Volume: `editions` 148,296; 38,668 of 126,204 books have ≥1 edition; publisher present on 144,112 editions (97%).
 - **Fresh ids** (editions aren't URL-facing) — no `reset_pk_sequence!`. Idempotency via `LegacyIdMap("Books::Edition")`: `save!` + `LegacyIdMap.record` in a **per-row transaction**.
 - Transformer is **PURE** (String-keyed hash in → symbol-keyed attrs out, no DB). `book_id` (direct passthrough — books preserve id) is set by the migrator; `language_id` has no legacy source (left nil).
 - `book_binding`: re-encode **by symbol, never copy ints**. Unknown non-nil legacy value → **raise**; `nil` → `nil`.
-- Write through the real `Books::Edition`: `edition_type` omitted (model default `:standard`); `metadata` is `jsonb NOT NULL`, so `nil` → `{}`.
+- `publisher_name`: new nullable column `books_editions.publisher_name`; extract via `metadata.dig("amazon", "ItemInfo", "ByLineInfo", "Manufacturer", "DisplayValue")`, blank→nil (`.presence`); `nil` if absent. **No** fallback to `ByLineInfo.Brand`.
+- Write through the real `Books::Edition`: `edition_type` omitted (model default `:standard`); `metadata` is `jsonb NOT NULL`, so `nil` → `{}` (full blob still copied).
 - `default_edition_id`: set in `finalize` by one set-based SQL `UPDATE` — most-popular edition (`popularity DESC NULLS LAST, id ASC`), books-with-editions only; editionless books stay `NULL` (**no synthesis**). Raw SQL bypasses AR callbacks (no `SearchIndexRequest` flood; `finalize` runs outside `without_search_indexing`).
 - Migrator tests are **connection-free**: stub `legacy_each` (Mocha `multiple_yields`); never open the legacy connection.
 - SKIP (deferred/out of scope): identifiers (`ol_edition_id`, `identifiers`/`flat_identifiers` jsonb), `book_versions`, `language_id`, `description`, `last_refreshed`.
@@ -26,14 +27,55 @@
 
 ---
 
-### Task 1: EditionTransformer (pure) + book_binding re-encoding
+### Task 1: Add `publisher_name` column to `books_editions`
+
+**Files:**
+- Create: migration `web-app/db/migrate/*_add_publisher_name_to_books_editions.rb`
+- Modify (auto): `web-app/db/schema.rb`, `web-app/app/models/books/edition.rb` (annotaterb schema comment)
+
+- [ ] **Step 1: Generate the migration**
+
+Run: `bin/rails generate migration AddPublisherNameToBooksEditions publisher_name:string`
+Expected: creates `db/migrate/<timestamp>_add_publisher_name_to_books_editions.rb` containing:
+
+```ruby
+class AddPublisherNameToBooksEditions < ActiveRecord::Migration[8.1]
+  def change
+    add_column :books_editions, :publisher_name, :string
+  end
+end
+```
+
+(No index — nothing queries `publisher_name` yet.)
+
+- [ ] **Step 2: Migrate**
+
+Run: `bin/rails db:migrate`
+Expected: migration runs; `db/schema.rb` updated with `publisher_name`; annotaterb re-annotates `app/models/books/edition.rb` with the new column.
+
+- [ ] **Step 3: Verify the column exists**
+
+Run: `bin/rails runner 'puts Books::Edition.column_names.include?("publisher_name")'`
+Expected: `true`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+bundle exec standardrb --fix db/migrate/*_add_publisher_name_to_books_editions.rb
+git add db/migrate/*_add_publisher_name_to_books_editions.rb db/schema.rb app/models/books/edition.rb
+git commit -m "Add publisher_name column to books_editions"
+```
+
+---
+
+### Task 2: EditionTransformer (pure) — binding re-encoding + publisher extraction
 
 **Files:**
 - Create: `web-app/app/lib/services/books_migration/edition_transformer.rb`
 - Test: `web-app/test/lib/services/books_migration/edition_transformer_test.rb`
 
 **Interfaces:**
-- Produces: `EditionTransformer.call(attrs) -> {title:, publication_year:, popularity:, book_binding:, metadata:}` (pure, String-keyed hash in). `book_binding` is a NEW `Books::Edition` enum **symbol** (or nil). No `book_id`/`language_id`/`edition_type` keys emitted.
+- Produces: `EditionTransformer.call(attrs) -> {title:, publication_year:, popularity:, book_binding:, publisher_name:, metadata:}` (pure, String-keyed hash in). `book_binding` is a NEW `Books::Edition` enum **symbol** (or nil); `publisher_name` is a String (or nil). No `book_id`/`language_id`/`edition_type` keys emitted.
 
 - [ ] **Step 1: Write the failing test**
 
@@ -85,6 +127,18 @@ class Services::BooksMigration::EditionTransformerTest < ActiveSupport::TestCase
   test "nil metadata becomes an empty hash (column is NOT NULL)" do
     assert_equal({}, transform("metadata" => nil)[:metadata])
   end
+
+  test "extracts publisher_name from the amazon ByLineInfo manufacturer path" do
+    md = {"amazon" => {"ItemInfo" => {"ByLineInfo" => {"Manufacturer" => {"DisplayValue" => "Random House"}}}}}
+    assert_equal "Random House", transform("metadata" => md)[:publisher_name]
+  end
+
+  test "publisher_name is nil when the manufacturer path is absent, blank, or metadata is nil" do
+    assert_nil transform("metadata" => {"amazon" => {"ItemInfo" => {}}})[:publisher_name]
+    blank = {"amazon" => {"ItemInfo" => {"ByLineInfo" => {"Manufacturer" => {"DisplayValue" => ""}}}}}
+    assert_nil transform("metadata" => blank)[:publisher_name]
+    assert_nil transform("metadata" => nil)[:publisher_name]
+  end
 end
 ```
 
@@ -103,9 +157,10 @@ module Services
     # Legacy `editions` row -> new Books::Edition attributes. PURE (String-keyed
     # hash in -> symbol-keyed attrs out, no DB). `book_id` (direct passthrough)
     # and `language_id` (no legacy source) are handled by the migrator. `edition_type`
-    # is omitted so the model default (:standard) applies. The legacy `book_binding`
-    # integer is re-encoded to the NEW enum BY SYMBOL (never by int) — the old and
-    # new enums assign different integers to the same names.
+    # is omitted so the model default (:standard) applies. `book_binding` is re-encoded
+    # to the NEW enum BY SYMBOL (never by int) — the old and new enums assign different
+    # integers to the same names. `publisher_name` is pulled from the legacy Amazon
+    # PA-API metadata (ByLineInfo.Manufacturer); the full metadata blob is still copied.
     class EditionTransformer
       # legacy book_binding int -> legacy symbol
       LEGACY_BINDING = {
@@ -122,12 +177,15 @@ module Services
         leather_bound: :leather_bound, other: :other
       }.freeze
 
+      PUBLISHER_PATH = ["amazon", "ItemInfo", "ByLineInfo", "Manufacturer", "DisplayValue"].freeze
+
       def self.call(attrs)
         {
           title: attrs["title"],
           publication_year: attrs["publication_year"],
           popularity: attrs["popularity"],
           book_binding: book_binding(attrs["book_binding"]),
+          publisher_name: publisher_name(attrs["metadata"]),
           metadata: attrs["metadata"] || {}
         }
       end
@@ -140,6 +198,12 @@ module Services
         BINDING_TO_NEW.fetch(legacy_sym)
       end
       private_class_method :book_binding
+
+      def self.publisher_name(metadata)
+        return nil unless metadata.is_a?(Hash)
+        metadata.dig(*PUBLISHER_PATH).presence
+      end
+      private_class_method :publisher_name
     end
   end
 end
@@ -148,19 +212,19 @@ end
 - [ ] **Step 4: Run it — verify it passes**
 
 Run: `bin/rails test test/lib/services/books_migration/edition_transformer_test.rb`
-Expected: PASS (6 runs).
+Expected: PASS (8 runs).
 
 - [ ] **Step 5: Lint + commit**
 
 ```bash
 bundle exec standardrb --fix app/lib/services/books_migration/edition_transformer.rb test/lib/services/books_migration/edition_transformer_test.rb
 git add app/lib/services/books_migration/edition_transformer.rb test/lib/services/books_migration/edition_transformer_test.rb
-git commit -m "Add EditionTransformer (pure book_binding re-encoding)"
+git commit -m "Add EditionTransformer (book_binding re-encode + publisher extraction)"
 ```
 
 ---
 
-### Task 2: LegacyBooks::Edition + EditionMigrator (fresh id + map + default_edition_id)
+### Task 3: LegacyBooks::Edition + EditionMigrator (fresh id + map + default_edition_id)
 
 **Files:**
 - Create: `web-app/app/models/legacy_books/edition.rb`
@@ -169,7 +233,7 @@ git commit -m "Add EditionTransformer (pure book_binding re-encoding)"
 
 **Interfaces:**
 - Consumes: `EditionTransformer.call`, `Migrator` base, `LegacyIdMap.record/lookup`, `Books::Edition`, `Books::Book`.
-- Produces: `EditionMigrator` (fresh id; records `LegacyIdMap(model: "Books::Edition")`; `book_id` direct; `finalize` sets `default_edition_id`). Result shape `{success:, data: {model: "Books::Edition", count:}}`.
+- Produces: `EditionMigrator` (fresh id; records `LegacyIdMap(model: "Books::Edition")`; `book_id` direct; persists `publisher_name`; `finalize` sets `default_edition_id`). Result shape `{success:, data: {model: "Books::Edition", count:}}`.
 
 - [ ] **Step 1: Create the legacy model**
 
@@ -197,12 +261,13 @@ class Services::BooksMigration::EditionMigratorTest < ActiveSupport::TestCase
     migrator.call
   end
 
-  test "creates editions with fresh ids, records the id map, and sets book_id directly" do
+  test "creates editions with fresh ids, records the id map, sets book_id, and extracts publisher_name" do
     book = Books::Book.create!(title: "Edition Parent")
+    md = {"amazon" => {"ItemInfo" => {"ByLineInfo" => {"Manufacturer" => {"DisplayValue" => "Penguin"}}}}}
 
     result = run_migrator([
       {"id" => 5001, "book_id" => book.id, "title" => "HC", "publication_year" => 1990,
-       "popularity" => 10, "book_binding" => 1, "metadata" => {"a" => 1}}
+       "popularity" => 10, "book_binding" => 1, "metadata" => md}
     ])
 
     assert result[:success], result[:error]
@@ -217,7 +282,8 @@ class Services::BooksMigration::EditionMigratorTest < ActiveSupport::TestCase
     assert_equal 1990, edition.publication_year
     assert_equal "hardcover", edition.book_binding
     assert_equal "standard", edition.edition_type
-    assert_equal({"a" => 1}, edition.metadata)
+    assert_equal "Penguin", edition.publisher_name
+    assert_equal md, edition.metadata
   end
 
   test "is idempotent: re-running updates in place without duplicating or remapping" do
@@ -331,12 +397,12 @@ Expected: all pass.
 ```bash
 bundle exec standardrb --fix app/models/legacy_books/edition.rb app/lib/services/books_migration/edition_migrator.rb test/lib/services/books_migration/edition_migrator_test.rb
 git add app/models/legacy_books/edition.rb app/lib/services/books_migration/edition_migrator.rb test/lib/services/books_migration/edition_migrator_test.rb
-git commit -m "Add editions migrator (fresh id + map + default_edition_id back-reference)"
+git commit -m "Add editions migrator (fresh id + map + publisher + default_edition_id)"
 ```
 
 ---
 
-### Task 3: Orchestrator wiring + end-to-end dev run
+### Task 4: Orchestrator wiring + end-to-end dev run
 
 **Files:**
 - Modify: `web-app/lib/tasks/data_migration.rake`
@@ -391,9 +457,9 @@ Expected: `orphan_edition_book_ids=0`. If non-zero, report the ids — the run w
 Then run:
 ```bash
 bin/rails data_migration:editions
-bin/rails runner 'puts "editions=#{Books::Edition.count} edition_maps=#{LegacyIdMap.where(model: "Books::Edition").count} books_with_default=#{Books::Book.where.not(default_edition_id: nil).count} pending_book_index=#{SearchIndexRequest.where(parent_type: "Books::Book").count}"'
+bin/rails runner 'puts "editions=#{Books::Edition.count} edition_maps=#{LegacyIdMap.where(model: "Books::Edition").count} books_with_default=#{Books::Book.where.not(default_edition_id: nil).count} with_publisher=#{Books::Edition.where.not(publisher_name: nil).count} pending_book_index=#{SearchIndexRequest.where(parent_type: "Books::Book").count}"'
 ```
-Expected: `editions` result `{success: true, ...}` `count: 148296`; then `editions=148296 edition_maps=148296 books_with_default=38668 pending_book_index=0`.
+Expected: `editions` result `{success: true, ...}` `count: 148296`; then `editions=148296 edition_maps=148296 books_with_default=38668 with_publisher=144112 pending_book_index=0`.
 
 > If a run returns `{success: false, ...}`, the error names the offending legacy edition id and the count that succeeded — report it; the run is idempotent, so it resumes after the row is understood.
 
@@ -402,14 +468,15 @@ Expected: `editions` result `{success: true, ...}` `count: 148296`; then `editio
 ## Self-Review
 
 **1. Spec coverage:**
-- editions → books_editions, fresh id + `LegacyIdMap`, per-row transaction idempotency → Task 2. ✓
-- `book_binding` re-encode by symbol, unknown→raise, nil→nil → Task 1. ✓
-- field mapping (title/publication_year/popularity/metadata nil→{}, edition_type default, book_id direct, language_id nil) → Tasks 1+2. ✓
-- `default_edition_id` set-based SQL, most-popular, editionless→NULL, no synthesis → Task 2 `finalize`. ✓
-- search suppression (load suppressed; finalize bypasses callbacks) → Task 2. ✓
-- orchestrator + e2e (+ orphan scan) → Task 3. ✓
+- `publisher_name` column + extraction (Amazon manufacturer path, blank→nil, no Brand fallback) → Tasks 1+2. ✓
+- editions → books_editions, fresh id + `LegacyIdMap`, per-row transaction idempotency → Task 3. ✓
+- `book_binding` re-encode by symbol, unknown→raise, nil→nil → Task 2. ✓
+- field mapping (title/publication_year/popularity/metadata nil→{}, edition_type default, book_id direct, language_id nil) → Tasks 2+3. ✓
+- `default_edition_id` set-based SQL, most-popular, editionless→NULL, no synthesis → Task 3 `finalize`. ✓
+- search suppression (load suppressed; finalize bypasses callbacks) → Task 3. ✓
+- orchestrator + e2e (+ orphan scan + publisher coverage) → Task 4. ✓
 - Skipped-by-design (identifiers, book_versions, language_id, description) — stated in Global Constraints. ✓
 
 **2. Placeholder scan:** No TBD/TODO; complete code in every code step.
 
-**3. Type consistency:** `EditionTransformer.call(attrs)` (String-keyed) → symbol-keyed hash, consistent Task 1↔2. `LegacyIdMap.record/lookup(model:, legacy_id:[, new_id:])` keyword signatures match Phase 1a. Subclass hooks (`legacy_model`, `model_key`, `upsert_row`, `finalize`) match the base contract. `model_key` == `"Books::Edition"` used consistently for both the result shape and the `LegacyIdMap` model key.
+**3. Type consistency:** `EditionTransformer.call(attrs)` (String-keyed) → symbol-keyed hash `{…, publisher_name:, metadata:}`, consistent Task 2↔3. `LegacyIdMap.record/lookup(model:, legacy_id:[, new_id:])` keyword signatures match Phase 1a. Subclass hooks (`legacy_model`, `model_key`, `upsert_row`, `finalize`) match the base contract. `model_key` == `"Books::Edition"` used consistently for both the result shape and the `LegacyIdMap` model key. `publisher_name` column (Task 1) exists before the migrator persists it (Task 3).

--- a/docs/superpowers/plans/2026-07-04-books-editions-migration.md
+++ b/docs/superpowers/plans/2026-07-04-books-editions-migration.md
@@ -1,0 +1,415 @@
+# Books Editions Migration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Migrate legacy `editions` → `books_editions` (fresh id + `LegacyIdMap`, `book_binding` re-encoded by symbol) and set `default_edition_id` on the already-migrated books, on top of the Phase 1a/1b ETL framework.
+
+**Architecture:** One more `Services::BooksMigration::Migrator` subclass reusing the base (batched read → pure `EditionTransformer` → idempotent upsert through the real `Books::Edition`, search suppressed). Editions take fresh auto ids; the `LegacyIdMap("Books::Edition")` is the dedup key (needed later by identifiers). `default_edition_id` is set in `finalize` by one set-based `UPDATE` (most-popular edition per book; editionless books stay NULL — no synthesis).
+
+**Tech Stack:** Rails 8.1, PostgreSQL 17, Minitest + Mocha + fixtures, `Services::` migrators.
+
+**Spec:** `docs/superpowers/specs/2026-07-04-books-editions-migration-design.md`.
+
+## Global Constraints
+
+- Run all commands from `/home/shane/dev/the-greatest/web-app`.
+- Lint with `bundle exec standardrb` (NOT rubocop). Tests: `bin/rails test`.
+- Legacy dev DB `the_greatest_books_legacy` on `localhost:6543`. Volume: `editions` 148,296; 38,668 of 126,204 books have ≥1 edition.
+- **Fresh ids** (editions aren't URL-facing) — no `reset_pk_sequence!`. Idempotency via `LegacyIdMap("Books::Edition")`: `save!` + `LegacyIdMap.record` in a **per-row transaction**.
+- Transformer is **PURE** (String-keyed hash in → symbol-keyed attrs out, no DB). `book_id` (direct passthrough — books preserve id) is set by the migrator; `language_id` has no legacy source (left nil).
+- `book_binding`: re-encode **by symbol, never copy ints**. Unknown non-nil legacy value → **raise**; `nil` → `nil`.
+- Write through the real `Books::Edition`: `edition_type` omitted (model default `:standard`); `metadata` is `jsonb NOT NULL`, so `nil` → `{}`.
+- `default_edition_id`: set in `finalize` by one set-based SQL `UPDATE` — most-popular edition (`popularity DESC NULLS LAST, id ASC`), books-with-editions only; editionless books stay `NULL` (**no synthesis**). Raw SQL bypasses AR callbacks (no `SearchIndexRequest` flood; `finalize` runs outside `without_search_indexing`).
+- Migrator tests are **connection-free**: stub `legacy_each` (Mocha `multiple_yields`); never open the legacy connection.
+- SKIP (deferred/out of scope): identifiers (`ol_edition_id`, `identifiers`/`flat_identifiers` jsonb), `book_versions`, `language_id`, `description`, `last_refreshed`.
+- Framework already on the branch base (`main`): `Services::BooksMigration::Migrator`, `LegacyBooks::Record`, `LegacyIdMap.record/lookup`, `without_search_indexing`, the language/author/book/book_author migrators, `data_migration:*` rake.
+
+---
+
+### Task 1: EditionTransformer (pure) + book_binding re-encoding
+
+**Files:**
+- Create: `web-app/app/lib/services/books_migration/edition_transformer.rb`
+- Test: `web-app/test/lib/services/books_migration/edition_transformer_test.rb`
+
+**Interfaces:**
+- Produces: `EditionTransformer.call(attrs) -> {title:, publication_year:, popularity:, book_binding:, metadata:}` (pure, String-keyed hash in). `book_binding` is a NEW `Books::Edition` enum **symbol** (or nil). No `book_id`/`language_id`/`edition_type` keys emitted.
+
+- [ ] **Step 1: Write the failing test**
+
+`test/lib/services/books_migration/edition_transformer_test.rb`:
+
+```ruby
+require "test_helper"
+
+class Services::BooksMigration::EditionTransformerTest < ActiveSupport::TestCase
+  def transform(overrides = {})
+    Services::BooksMigration::EditionTransformer.call({
+      "title" => "First Edition", "publication_year" => 1937,
+      "popularity" => 42, "book_binding" => 1, "metadata" => {"src" => "x"}
+    }.merge(overrides))
+  end
+
+  test "maps core fields directly" do
+    attrs = transform
+    assert_equal "First Edition", attrs[:title]
+    assert_equal 1937, attrs[:publication_year]
+    assert_equal 42, attrs[:popularity]
+    assert_equal({"src" => "x"}, attrs[:metadata])
+  end
+
+  test "does not emit edition_type, book_id, or language_id" do
+    attrs = transform
+    refute attrs.key?(:edition_type)
+    refute attrs.key?(:book_id)
+    refute attrs.key?(:language_id)
+  end
+
+  test "re-encodes each legacy book_binding to the new symbol by name" do
+    {0 => :paperback, 1 => :hardcover, 2 => :ebook, 3 => :audiobook,
+     4 => :mass_market, 5 => :audiobook, 6 => :library_binding,
+     7 => :other, 8 => :leather_bound, 9 => :other}.each do |legacy_int, new_sym|
+      assert_equal new_sym, transform("book_binding" => legacy_int)[:book_binding],
+        "legacy binding #{legacy_int} should map to #{new_sym}"
+    end
+  end
+
+  test "nil book_binding stays nil" do
+    assert_nil transform("book_binding" => nil)[:book_binding]
+  end
+
+  test "unknown book_binding raises" do
+    assert_raises(RuntimeError) { transform("book_binding" => 99) }
+  end
+
+  test "nil metadata becomes an empty hash (column is NOT NULL)" do
+    assert_equal({}, transform("metadata" => nil)[:metadata])
+  end
+end
+```
+
+- [ ] **Step 2: Run it — verify it fails**
+
+Run: `bin/rails test test/lib/services/books_migration/edition_transformer_test.rb`
+Expected: FAIL — `uninitialized constant ...EditionTransformer`.
+
+- [ ] **Step 3: Write the transformer**
+
+`app/lib/services/books_migration/edition_transformer.rb`:
+
+```ruby
+module Services
+  module BooksMigration
+    # Legacy `editions` row -> new Books::Edition attributes. PURE (String-keyed
+    # hash in -> symbol-keyed attrs out, no DB). `book_id` (direct passthrough)
+    # and `language_id` (no legacy source) are handled by the migrator. `edition_type`
+    # is omitted so the model default (:standard) applies. The legacy `book_binding`
+    # integer is re-encoded to the NEW enum BY SYMBOL (never by int) — the old and
+    # new enums assign different integers to the same names.
+    class EditionTransformer
+      # legacy book_binding int -> legacy symbol
+      LEGACY_BINDING = {
+        0 => :paperback, 1 => :hardcover, 2 => :ebook, 3 => :audible,
+        4 => :mass_market_paperback, 5 => :audio, 6 => :library_binding,
+        7 => :collectable, 8 => :leather_bound, 9 => :other
+      }.freeze
+
+      # legacy symbol -> new Books::Edition book_binding symbol
+      BINDING_TO_NEW = {
+        paperback: :paperback, hardcover: :hardcover, ebook: :ebook,
+        audible: :audiobook, mass_market_paperback: :mass_market, audio: :audiobook,
+        library_binding: :library_binding, collectable: :other,
+        leather_bound: :leather_bound, other: :other
+      }.freeze
+
+      def self.call(attrs)
+        {
+          title: attrs["title"],
+          publication_year: attrs["publication_year"],
+          popularity: attrs["popularity"],
+          book_binding: book_binding(attrs["book_binding"]),
+          metadata: attrs["metadata"] || {}
+        }
+      end
+
+      def self.book_binding(legacy_int)
+        return nil if legacy_int.nil?
+        legacy_sym = LEGACY_BINDING.fetch(legacy_int) do
+          raise "unknown legacy book_binding: #{legacy_int.inspect}"
+        end
+        BINDING_TO_NEW.fetch(legacy_sym)
+      end
+      private_class_method :book_binding
+    end
+  end
+end
+```
+
+- [ ] **Step 4: Run it — verify it passes**
+
+Run: `bin/rails test test/lib/services/books_migration/edition_transformer_test.rb`
+Expected: PASS (6 runs).
+
+- [ ] **Step 5: Lint + commit**
+
+```bash
+bundle exec standardrb --fix app/lib/services/books_migration/edition_transformer.rb test/lib/services/books_migration/edition_transformer_test.rb
+git add app/lib/services/books_migration/edition_transformer.rb test/lib/services/books_migration/edition_transformer_test.rb
+git commit -m "Add EditionTransformer (pure book_binding re-encoding)"
+```
+
+---
+
+### Task 2: LegacyBooks::Edition + EditionMigrator (fresh id + map + default_edition_id)
+
+**Files:**
+- Create: `web-app/app/models/legacy_books/edition.rb`
+- Create: `web-app/app/lib/services/books_migration/edition_migrator.rb`
+- Test: `web-app/test/lib/services/books_migration/edition_migrator_test.rb`
+
+**Interfaces:**
+- Consumes: `EditionTransformer.call`, `Migrator` base, `LegacyIdMap.record/lookup`, `Books::Edition`, `Books::Book`.
+- Produces: `EditionMigrator` (fresh id; records `LegacyIdMap(model: "Books::Edition")`; `book_id` direct; `finalize` sets `default_edition_id`). Result shape `{success:, data: {model: "Books::Edition", count:}}`.
+
+- [ ] **Step 1: Create the legacy model**
+
+`app/models/legacy_books/edition.rb`:
+
+```ruby
+module LegacyBooks
+  class Edition < Record
+    self.table_name = "editions"
+  end
+end
+```
+
+- [ ] **Step 2: Write the failing migrator test**
+
+`test/lib/services/books_migration/edition_migrator_test.rb`:
+
+```ruby
+require "test_helper"
+
+class Services::BooksMigration::EditionMigratorTest < ActiveSupport::TestCase
+  def run_migrator(rows)
+    migrator = Services::BooksMigration::EditionMigrator.new
+    migrator.stubs(:legacy_each).multiple_yields(*rows.zip)
+    migrator.call
+  end
+
+  test "creates editions with fresh ids, records the id map, and sets book_id directly" do
+    book = Books::Book.create!(title: "Edition Parent")
+
+    result = run_migrator([
+      {"id" => 5001, "book_id" => book.id, "title" => "HC", "publication_year" => 1990,
+       "popularity" => 10, "book_binding" => 1, "metadata" => {"a" => 1}}
+    ])
+
+    assert result[:success], result[:error]
+    assert_equal 1, result[:data][:count]
+    assert_equal "Books::Edition", result[:data][:model]
+
+    new_id = LegacyIdMap.lookup(model: "Books::Edition", legacy_id: 5001)
+    assert_not_nil new_id
+    edition = Books::Edition.find(new_id)
+    assert_equal book.id, edition.book_id
+    assert_equal "HC", edition.title
+    assert_equal 1990, edition.publication_year
+    assert_equal "hardcover", edition.book_binding
+    assert_equal "standard", edition.edition_type
+    assert_equal({"a" => 1}, edition.metadata)
+  end
+
+  test "is idempotent: re-running updates in place without duplicating or remapping" do
+    book = Books::Book.create!(title: "Idem Edition Parent")
+    run_migrator([{"id" => 5002, "book_id" => book.id, "title" => "V1", "book_binding" => 0}])
+    first_id = LegacyIdMap.lookup(model: "Books::Edition", legacy_id: 5002)
+
+    assert_no_difference -> { Books::Edition.count } do
+      run_migrator([{"id" => 5002, "book_id" => book.id, "title" => "V2", "book_binding" => 0}])
+    end
+    assert_equal first_id, LegacyIdMap.lookup(model: "Books::Edition", legacy_id: 5002)
+    assert_equal "V2", Books::Edition.find(first_id).title
+  end
+
+  test "suppresses search indexing during the load" do
+    book = Books::Book.create!(title: "Quiet Edition Parent")
+    assert_no_difference -> { SearchIndexRequest.count } do
+      run_migrator([{"id" => 5003, "book_id" => book.id, "title" => "Q", "book_binding" => nil}])
+    end
+  end
+
+  test "finalize sets default_edition_id to the most-popular edition" do
+    book = Books::Book.create!(title: "Popularity Parent")
+    run_migrator([
+      {"id" => 5004, "book_id" => book.id, "title" => "Low", "popularity" => 1, "book_binding" => 0},
+      {"id" => 5005, "book_id" => book.id, "title" => "High", "popularity" => 99, "book_binding" => 0}
+    ])
+    high_id = LegacyIdMap.lookup(model: "Books::Edition", legacy_id: 5005)
+    assert_equal high_id, book.reload.default_edition_id
+  end
+
+  test "a book with no editions keeps default_edition_id nil" do
+    editionless = Books::Book.create!(title: "Editionless Parent")
+    other = Books::Book.create!(title: "Has Edition")
+    run_migrator([{"id" => 5006, "book_id" => other.id, "title" => "E", "book_binding" => 0}])
+    assert_nil editionless.reload.default_edition_id
+  end
+end
+```
+
+- [ ] **Step 3: Run it — verify it fails**
+
+Run: `bin/rails test test/lib/services/books_migration/edition_migrator_test.rb`
+Expected: FAIL — `uninitialized constant ...EditionMigrator`.
+
+- [ ] **Step 4: Write the migrator**
+
+`app/lib/services/books_migration/edition_migrator.rb`:
+
+```ruby
+module Services
+  module BooksMigration
+    # Fresh-id migrator: legacy editions -> books_editions. Editions aren't
+    # URL-facing, so they take new auto ids; the LegacyIdMap ("Books::Edition")
+    # is the dedup key (editions have no natural business key) and is needed by
+    # the later identifiers pass. book_id is a direct passthrough (books preserve
+    # their id). finalize back-references default_edition_id onto books_books.
+    class EditionMigrator < Migrator
+      private
+
+      def legacy_model
+        LegacyBooks::Edition
+      end
+
+      def model_key
+        "Books::Edition"
+      end
+
+      def upsert_row(attrs)
+        Books::Edition.transaction do
+          new_id = LegacyIdMap.lookup(model: model_key, legacy_id: attrs["id"])
+          edition = new_id ? Books::Edition.find(new_id) : Books::Edition.new
+          edition.assign_attributes(EditionTransformer.call(attrs))
+          edition.book_id = attrs["book_id"]
+          edition.save!
+          LegacyIdMap.record(model: model_key, legacy_id: attrs["id"], new_id: edition.id)
+        end
+      end
+
+      # Set each book's default_edition_id to its most-popular edition (popularity
+      # desc, nulls last, id asc), for books that have editions only. Set-based SQL
+      # bypasses AR callbacks (no SearchIndexRequest flood — finalize runs OUTSIDE
+      # the without_search_indexing block) and is idempotent. Editionless books
+      # keep default_edition_id NULL (no synthesis).
+      def finalize
+        Books::Book.connection.execute(<<~SQL)
+          UPDATE books_books b
+          SET default_edition_id = e.id
+          FROM (
+            SELECT DISTINCT ON (book_id) id, book_id
+            FROM books_editions
+            ORDER BY book_id, popularity DESC NULLS LAST, id ASC
+          ) e
+          WHERE e.book_id = b.id
+        SQL
+      end
+    end
+  end
+end
+```
+
+- [ ] **Step 5: Run it — verify it passes**
+
+Run: `bin/rails test test/lib/services/books_migration/edition_migrator_test.rb`
+Expected: PASS (5 runs). Also run the whole migration suite to confirm no regression:
+`bin/rails test test/lib/services/books_migration/`
+Expected: all pass.
+
+- [ ] **Step 6: Lint + commit**
+
+```bash
+bundle exec standardrb --fix app/models/legacy_books/edition.rb app/lib/services/books_migration/edition_migrator.rb test/lib/services/books_migration/edition_migrator_test.rb
+git add app/models/legacy_books/edition.rb app/lib/services/books_migration/edition_migrator.rb test/lib/services/books_migration/edition_migrator_test.rb
+git commit -m "Add editions migrator (fresh id + map + default_edition_id back-reference)"
+```
+
+---
+
+### Task 3: Orchestrator wiring + end-to-end dev run
+
+**Files:**
+- Modify: `web-app/lib/tasks/data_migration.rake`
+
+**Interfaces:**
+- Consumes: `EditionMigrator`.
+- Produces: `data_migration:editions`; `:all` runs `[:languages, :authors, :books, :book_authors, :editions]`.
+
+- [ ] **Step 1: Add the task + update `:all`**
+
+In `lib/tasks/data_migration.rake`, add after the `book_authors` task:
+
+```ruby
+  desc "Migrate legacy editions into books_editions (fresh ids + map; sets default_edition_id)"
+  task editions: :environment do
+    pp Services::BooksMigration::EditionMigrator.call
+  end
+```
+
+and change the `:all` line to:
+
+```ruby
+  task all: [:languages, :authors, :books, :book_authors, :editions]
+```
+
+- [ ] **Step 2: Verify the tasks register**
+
+Run: `bin/rails -T data_migration`
+Expected: lists `languages`, `authors`, `books`, `book_authors`, `editions`, `all`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add lib/tasks/data_migration.rake
+git commit -m "Wire editions into data_migration orchestrator"
+```
+
+- [ ] **Step 4: End-to-end dev run against the real legacy DB**
+
+> `editions` (148k) writes via AR `save!`, so the run takes roughly 8–12 minutes. Books/authors/languages are already migrated in dev; run editions directly.
+
+First, proactively scan for orphaned edition `book_id`s (a legacy edition whose book wasn't migrated would raise an FK error, named by the per-row error context):
+
+```bash
+bin/rails runner '
+klass = Class.new(LegacyBooks::Record) { self.table_name = "editions" }
+orphans = klass.where.not(book_id: nil).where.not(book_id: Books::Book.select(:id)).count
+puts "orphan_edition_book_ids=#{orphans}"'
+```
+Expected: `orphan_edition_book_ids=0`. If non-zero, report the ids — the run will name the first offending edition, and it is idempotent/resumable.
+
+Then run:
+```bash
+bin/rails data_migration:editions
+bin/rails runner 'puts "editions=#{Books::Edition.count} edition_maps=#{LegacyIdMap.where(model: "Books::Edition").count} books_with_default=#{Books::Book.where.not(default_edition_id: nil).count} pending_book_index=#{SearchIndexRequest.where(parent_type: "Books::Book").count}"'
+```
+Expected: `editions` result `{success: true, ...}` `count: 148296`; then `editions=148296 edition_maps=148296 books_with_default=38668 pending_book_index=0`.
+
+> If a run returns `{success: false, ...}`, the error names the offending legacy edition id and the count that succeeded — report it; the run is idempotent, so it resumes after the row is understood.
+
+---
+
+## Self-Review
+
+**1. Spec coverage:**
+- editions → books_editions, fresh id + `LegacyIdMap`, per-row transaction idempotency → Task 2. ✓
+- `book_binding` re-encode by symbol, unknown→raise, nil→nil → Task 1. ✓
+- field mapping (title/publication_year/popularity/metadata nil→{}, edition_type default, book_id direct, language_id nil) → Tasks 1+2. ✓
+- `default_edition_id` set-based SQL, most-popular, editionless→NULL, no synthesis → Task 2 `finalize`. ✓
+- search suppression (load suppressed; finalize bypasses callbacks) → Task 2. ✓
+- orchestrator + e2e (+ orphan scan) → Task 3. ✓
+- Skipped-by-design (identifiers, book_versions, language_id, description) — stated in Global Constraints. ✓
+
+**2. Placeholder scan:** No TBD/TODO; complete code in every code step.
+
+**3. Type consistency:** `EditionTransformer.call(attrs)` (String-keyed) → symbol-keyed hash, consistent Task 1↔2. `LegacyIdMap.record/lookup(model:, legacy_id:[, new_id:])` keyword signatures match Phase 1a. Subclass hooks (`legacy_model`, `model_key`, `upsert_row`, `finalize`) match the base contract. `model_key` == `"Books::Edition"` used consistently for both the result shape and the `LegacyIdMap` model key.

--- a/docs/superpowers/specs/2026-07-04-books-editions-migration-design.md
+++ b/docs/superpowers/specs/2026-07-04-books-editions-migration-design.md
@@ -1,0 +1,130 @@
+# Books Editions Migration — Design
+
+**Status:** Approved 2026-07-04 (one flagged decision — see `default_edition_id`).
+**Scope:** A single migration increment on top of Phase 1a (languages/authors) and Phase 1b (books/book_authors, both merged): legacy `editions` → `books_editions`, plus the `default_edition_id` back-reference on the already-migrated `books_books`.
+**Parent design:** `docs/superpowers/specs/2026-07-03-old-site-data-migration-design.md`.
+
+## Goal
+
+Migrate the legacy `editions` table (148,296 rows) into `books_editions` with **fresh auto ids + `LegacyIdMap("Books::Edition")`** (the map is required by the later identifiers pass), writing through the real `Books::Edition` model, search suppressed. Then set `default_edition_id` on `books_books` for the books that have editions.
+
+## Framework reused (already on `main`)
+
+`Services::BooksMigration::Migrator` base (batched, idempotent, `without_search_indexing`, subclass hooks `legacy_model`/`model_key`/`upsert_row`/optional `finalize`, per-row error context), `LegacyBooks::Record` read-only replica base, `LegacyIdMap.record/lookup`, the `data_migration:*` rake orchestrator, and the pure-transformer pattern.
+
+## Source → target field mapping
+
+Legacy `editions` columns: `id, title, description, identifiers, ol_edition_id, metadata, publication_year, book_binding, book_id, last_refreshed, popularity, created_at, updated_at, flat_identifiers`.
+
+New `books_editions` columns: `id, book_binding, edition_type(NOT NULL default standard), metadata(jsonb NOT NULL), page_count, popularity, publication_year, subtitle, title, volume_number, book_id(NOT NULL), language_id`.
+
+| Legacy | New | Handling |
+|---|---|---|
+| `title` | `title` | direct (0 blank in legacy) |
+| `publication_year` | `publication_year` | direct |
+| `popularity` | `popularity` | direct (30,476 nil — allowed) |
+| `book_binding` (int) | `book_binding` | **enum re-encode by symbol** (see below) |
+| `metadata` (jsonb) | `metadata` | copy as-is; `nil` → `{}` (target is NOT NULL; all 148,296 rows have it) |
+| `book_id` | `book_id` | direct **passthrough** — books preserve their id, so no remap. Set in the migrator (parent FK). |
+| — | `edition_type` | **omit** → model default `:standard` |
+| `description` | — | **drop** (0 non-blank in legacy; no target column) |
+| `last_refreshed` | — | drop (no target column) |
+| `language_id` | `language_id` = `nil` | legacy `editions` has **no language column** (the parent design's "remap language" was aspirational) |
+| `ol_edition_id`, `identifiers`, `flat_identifiers` | — | **deferred to the identifiers increment** |
+
+`subtitle`, `page_count`, `volume_number`: no legacy source → left nil.
+
+The transformer is **pure** (String-keyed hash in → symbol-keyed attrs out, no DB): it returns `{title:, publication_year:, popularity:, book_binding:, metadata:}`. `book_id` (the parent FK, a direct passthrough) is set by the migrator; `language_id` has no legacy source and is left nil (the model defaults it). This mirrors the established transformer/migrator split.
+
+## `book_binding` re-encoding (map by symbol — never copy ints)
+
+Legacy enum: `{paperback:0, hardcover:1, ebook:2, audible:3, mass_market_paperback:4, audio:5, library_binding:6, collectable:7, leather_bound:8, other:9}`.
+New `Books::Edition` enum: `{hardcover:0, paperback:1, mass_market:2, ebook:3, audiobook:4, library_binding:5, leather_bound:6, other:7}`.
+
+Two-step map (legacy int → legacy symbol → new symbol), assigning the **new symbol** to the enum (never an int):
+
+```
+legacy int → legacy symbol → new symbol
+0  paperback             → :paperback
+1  hardcover             → :hardcover
+2  ebook                 → :ebook
+3  audible               → :audiobook
+4  mass_market_paperback → :mass_market
+5  audio                 → :audiobook
+6  library_binding       → :library_binding
+7  collectable           → :other        (0 rows in legacy)
+8  leather_bound         → :leather_bound
+9  other                 → :other
+nil                      → nil
+```
+
+All legacy values present (0,1,2,3,4,5,6,8,9,nil) are covered. An unknown non-nil legacy value → **raise** (the base Migrator's per-row rescue names the offending edition's legacy id). This is the enum re-encoding landmine the parent design warns about; the two-step map makes the symbol mapping explicit.
+
+Legacy `book_binding` distribution (for reference): 0→66,874 · 1→23,198 · 2→14,034 · 3→32,528 · 4→4,097 · 5→928 · 6→318 · 8→841 · 9→5,445 · nil→33.
+
+## Id strategy & idempotency
+
+Editions are not URL-facing, so they take **fresh auto ids** from the sequence (no explicit-id inserts, so **no `reset_pk_sequence!`** — unlike the preserved-id book/author migrators). Editions have no natural business key, so the **`LegacyIdMap` is the dedup key**:
+
+```
+new_id = LegacyIdMap.lookup(model: "Books::Edition", legacy_id: attrs["id"])
+edition = new_id ? Books::Edition.find(new_id) : Books::Edition.new
+edition.assign_attributes(EditionTransformer.call(attrs))
+edition.book_id = attrs["book_id"]
+edition.save!
+LegacyIdMap.record(model: "Books::Edition", legacy_id: attrs["id"], new_id: edition.id)
+```
+
+`save!` + `LegacyIdMap.record` run in a **per-row transaction** so a crash between them can't leave a mapped-but-unrecorded edition that a re-run would duplicate. Re-running finds the existing edition via the map and updates it in place — idempotent.
+
+## `default_edition_id` back-reference — ⚠️ flagged decision
+
+**Data:** 87,536 of 126,204 books (69%) have **no** legacy edition; only 38,668 do.
+
+**Decision (made in the owner's absence — confirm or override):** do **not** fabricate editions. In `finalize`, a single set-based SQL statement sets `default_edition_id` to each book's most-popular edition, for books that have editions only:
+
+```sql
+UPDATE books_books b
+SET default_edition_id = e.id
+FROM (
+  SELECT DISTINCT ON (book_id) id, book_id
+  FROM books_editions
+  ORDER BY book_id, popularity DESC NULLS LAST, id ASC
+) e
+WHERE e.book_id = b.id;
+```
+
+The 87,536 editionless books keep `default_edition_id = NULL` (the FK is nullable, `ON DELETE nullify`). This statement bypasses AR callbacks entirely (no `SearchIndexRequest` flood — important because the base Migrator's `finalize` runs **outside** the `without_search_indexing` block, and `Books::Book` includes `SearchIndexable`). It is deterministic and idempotent (re-running recomputes the same pick).
+
+**Rejected alternative:** synthesize a minimal edition (title = book title, `edition_type: :standard`) for each editionless book and point `default_edition_id` at it (the parent design's original wording). Rejected for now because it fabricates ~87,536 edition rows and the books public UI is still deferred, so nothing consumes `default_edition_id` yet — YAGNI. Easy to add later as an additive step if the UI needs a guaranteed default edition.
+
+## Search suppression
+
+The edition-creation pass runs inside the base Migrator's `without_search_indexing`. `Books::Edition` has no `SearchIndexable` include and no reindex callbacks, so it has no search side effects anyway (belt-and-suspenders). The `default_edition_id` `UPDATE` uses raw set-based SQL (no callbacks), so it also creates no index requests.
+
+## Orchestrator
+
+Add `data_migration:editions` (runs `Services::BooksMigration::EditionMigrator.call`); extend `:all` to `[:languages, :authors, :books, :book_authors, :editions]` (editions after books; independent of book_authors).
+
+## Files
+
+- Create `web-app/app/models/legacy_books/edition.rb` (`self.table_name = "editions"`).
+- Create `web-app/app/lib/services/books_migration/edition_transformer.rb` (pure).
+- Create `web-app/app/lib/services/books_migration/edition_migrator.rb` (fresh id + map, `finalize` = `default_edition_id` back-reference).
+- Modify `web-app/lib/tasks/data_migration.rake`.
+- Tests: `edition_transformer_test.rb`, `edition_migrator_test.rb`.
+
+## Testing
+
+Connection-free unit tests (stub `legacy_each` with Mocha `multiple_yields`; never open the legacy connection):
+
+- **Transformer:** each legacy binding int maps to the correct new symbol; `audible` and `audio` both → `:audiobook`; `collectable` → `:other`; `nil` binding → `nil`; unknown int → raise; `metadata` nil → `{}`; `edition_type` not emitted (model default applies); pure (no DB).
+- **Migrator:** creates editions with fresh ids, records `LegacyIdMap("Books::Edition")`, sets `book_id` directly; idempotent (re-run updates in place, no dupes, map stable); search indexing suppressed during load; `finalize` sets `default_edition_id` to the most-popular edition (popularity desc, nulls last, id asc tiebreak) and leaves a book with no editions at `NULL`.
+
+## End-to-end verification (real legacy DB, dev target)
+
+Run `data_migration:editions`; expect `EditionMigrator.call` → `{success: true, count: 148296}`; `Books::Edition.count == 148296`; `LegacyIdMap.where(model: "Books::Edition").count == 148296`; `Books::Book.where.not(default_edition_id: nil).count == 38668`; `pending_book_index == 0`. Proactively scan for legacy editions whose `book_id` has no migrated book (orphaned FK) before/after the run, the way the blank-title scan preempted issues in Phase 1b.
+
+## Out of scope (per parent design)
+
+Identifiers (`ol_edition_id`, `identifiers`/`flat_identifiers` jsonb, edition-level ISBN/ASIN → deferred to the identifiers increment), `book_versions`, edition `language_id` (no legacy source).

--- a/docs/superpowers/specs/2026-07-04-books-editions-migration-design.md
+++ b/docs/superpowers/specs/2026-07-04-books-editions-migration-design.md
@@ -1,6 +1,6 @@
 # Books Editions Migration — Design
 
-**Status:** Approved 2026-07-04 (one flagged decision — see `default_edition_id`).
+**Status:** Approved 2026-07-04. `default_edition_id` = leave NULL for editionless books (no synthesis) — confirmed by owner.
 **Scope:** A single migration increment on top of Phase 1a (languages/authors) and Phase 1b (books/book_authors, both merged): legacy `editions` → `books_editions`, plus the `default_edition_id` back-reference on the already-migrated `books_books`.
 **Parent design:** `docs/superpowers/specs/2026-07-03-old-site-data-migration-design.md`.
 
@@ -77,11 +77,11 @@ LegacyIdMap.record(model: "Books::Edition", legacy_id: attrs["id"], new_id: edit
 
 `save!` + `LegacyIdMap.record` run in a **per-row transaction** so a crash between them can't leave a mapped-but-unrecorded edition that a re-run would duplicate. Re-running finds the existing edition via the map and updates it in place — idempotent.
 
-## `default_edition_id` back-reference — ⚠️ flagged decision
+## `default_edition_id` back-reference
 
 **Data:** 87,536 of 126,204 books (69%) have **no** legacy edition; only 38,668 do.
 
-**Decision (made in the owner's absence — confirm or override):** do **not** fabricate editions. In `finalize`, a single set-based SQL statement sets `default_edition_id` to each book's most-popular edition, for books that have editions only:
+**Decision (confirmed by owner 2026-07-04):** do **not** fabricate editions. In `finalize`, a single set-based SQL statement sets `default_edition_id` to each book's most-popular edition, for books that have editions only:
 
 ```sql
 UPDATE books_books b

--- a/docs/superpowers/specs/2026-07-04-books-editions-migration-design.md
+++ b/docs/superpowers/specs/2026-07-04-books-editions-migration-design.md
@@ -25,6 +25,7 @@ New `books_editions` columns: `id, book_binding, edition_type(NOT NULL default s
 | `popularity` | `popularity` | direct (30,476 nil — allowed) |
 | `book_binding` (int) | `book_binding` | **enum re-encode by symbol** (see below) |
 | `metadata` (jsonb) | `metadata` | copy as-is; `nil` → `{}` (target is NOT NULL; all 148,296 rows have it) |
+| `metadata → amazon.ItemInfo.ByLineInfo.Manufacturer.DisplayValue` | `publisher_name` (**new column**) | extract publisher (97% coverage — see below); `nil` if absent |
 | `book_id` | `book_id` | direct **passthrough** — books preserve their id, so no remap. Set in the migrator (parent FK). |
 | — | `edition_type` | **omit** → model default `:standard` |
 | `description` | — | **drop** (0 non-blank in legacy; no target column) |
@@ -34,7 +35,11 @@ New `books_editions` columns: `id, book_binding, edition_type(NOT NULL default s
 
 `subtitle`, `page_count`, `volume_number`: no legacy source → left nil.
 
-The transformer is **pure** (String-keyed hash in → symbol-keyed attrs out, no DB): it returns `{title:, publication_year:, popularity:, book_binding:, metadata:}`. `book_id` (the parent FK, a direct passthrough) is set by the migrator; `language_id` has no legacy source and is left nil (the model defaults it). This mirrors the established transformer/migrator split.
+The transformer is **pure** (String-keyed hash in → symbol-keyed attrs out, no DB): it returns `{title:, publication_year:, popularity:, book_binding:, publisher_name:, metadata:}`. `book_id` (the parent FK, a direct passthrough) is set by the migrator; `language_id` has no legacy source and is left nil (the model defaults it). This mirrors the established transformer/migrator split.
+
+## Publisher name (new column)
+
+The legacy `metadata` is an Amazon PA-API v5 response (every edition has a single top-level `amazon` key). The publisher lives at `amazon.ItemInfo.ByLineInfo.Manufacturer.DisplayValue` — present on **144,112 of 148,296 editions (97%)**, with clean values ("Random House Publishing Group", "Modern Library Inc", "Tantor Media", …). `Books::Edition` has no publisher column today, so a schema migration adds `publisher_name :string` (nullable, no index — nothing queries it yet). The transformer extracts it via `metadata.dig("amazon", "ItemInfo", "ByLineInfo", "Manufacturer", "DisplayValue")`, coerced blank→nil (`.presence`); `nil` for the ~3% without it. It does **not** fall back to `ByLineInfo.Brand.DisplayValue` (a different semantic — imprint/brand, e.g. "Audible"). The full `metadata` blob is still copied through, so the raw data remains available.
 
 ## `book_binding` re-encoding (map by symbol — never copy ints)
 
@@ -108,6 +113,7 @@ Add `data_migration:editions` (runs `Services::BooksMigration::EditionMigrator.c
 
 ## Files
 
+- Migration: `add_column :books_editions, :publisher_name, :string` (via `bin/rails generate migration`).
 - Create `web-app/app/models/legacy_books/edition.rb` (`self.table_name = "editions"`).
 - Create `web-app/app/lib/services/books_migration/edition_transformer.rb` (pure).
 - Create `web-app/app/lib/services/books_migration/edition_migrator.rb` (fresh id + map, `finalize` = `default_edition_id` back-reference).
@@ -118,12 +124,12 @@ Add `data_migration:editions` (runs `Services::BooksMigration::EditionMigrator.c
 
 Connection-free unit tests (stub `legacy_each` with Mocha `multiple_yields`; never open the legacy connection):
 
-- **Transformer:** each legacy binding int maps to the correct new symbol; `audible` and `audio` both → `:audiobook`; `collectable` → `:other`; `nil` binding → `nil`; unknown int → raise; `metadata` nil → `{}`; `edition_type` not emitted (model default applies); pure (no DB).
-- **Migrator:** creates editions with fresh ids, records `LegacyIdMap("Books::Edition")`, sets `book_id` directly; idempotent (re-run updates in place, no dupes, map stable); search indexing suppressed during load; `finalize` sets `default_edition_id` to the most-popular edition (popularity desc, nulls last, id asc tiebreak) and leaves a book with no editions at `NULL`.
+- **Transformer:** each legacy binding int maps to the correct new symbol; `audible` and `audio` both → `:audiobook`; `collectable` → `:other`; `nil` binding → `nil`; unknown int → raise; `metadata` nil → `{}`; **`publisher_name` extracted from the Amazon manufacturer path, nil when absent/blank**; `edition_type` not emitted (model default applies); pure (no DB).
+- **Migrator:** creates editions with fresh ids, records `LegacyIdMap("Books::Edition")`, sets `book_id` directly, **persists `publisher_name` while preserving the full `metadata`**; idempotent (re-run updates in place, no dupes, map stable); search indexing suppressed during load; `finalize` sets `default_edition_id` to the most-popular edition (popularity desc, nulls last, id asc tiebreak) and leaves a book with no editions at `NULL`.
 
 ## End-to-end verification (real legacy DB, dev target)
 
-Run `data_migration:editions`; expect `EditionMigrator.call` → `{success: true, count: 148296}`; `Books::Edition.count == 148296`; `LegacyIdMap.where(model: "Books::Edition").count == 148296`; `Books::Book.where.not(default_edition_id: nil).count == 38668`; `pending_book_index == 0`. Proactively scan for legacy editions whose `book_id` has no migrated book (orphaned FK) before/after the run, the way the blank-title scan preempted issues in Phase 1b.
+Run `data_migration:editions`; expect `EditionMigrator.call` → `{success: true, count: 148296}`; `Books::Edition.count == 148296`; `LegacyIdMap.where(model: "Books::Edition").count == 148296`; `Books::Book.where.not(default_edition_id: nil).count == 38668`; `Books::Edition.where.not(publisher_name: nil).count == 144112`; `pending_book_index == 0`. Proactively scan for legacy editions whose `book_id` has no migrated book (orphaned FK) before/after the run, the way the blank-title scan preempted issues in Phase 1b.
 
 ## Out of scope (per parent design)
 

--- a/web-app/app/lib/services/books_migration/edition_migrator.rb
+++ b/web-app/app/lib/services/books_migration/edition_migrator.rb
@@ -1,0 +1,49 @@
+module Services
+  module BooksMigration
+    # Fresh-id migrator: legacy editions -> books_editions. Editions aren't
+    # URL-facing, so they take new auto ids; the LegacyIdMap ("Books::Edition")
+    # is the dedup key (editions have no natural business key) and is needed by
+    # the later identifiers pass. book_id is a direct passthrough (books preserve
+    # their id). finalize back-references default_edition_id onto books_books.
+    class EditionMigrator < Migrator
+      private
+
+      def legacy_model
+        LegacyBooks::Edition
+      end
+
+      def model_key
+        "Books::Edition"
+      end
+
+      def upsert_row(attrs)
+        Books::Edition.transaction do
+          new_id = LegacyIdMap.lookup(model: model_key, legacy_id: attrs["id"])
+          edition = new_id ? Books::Edition.find(new_id) : Books::Edition.new
+          edition.assign_attributes(EditionTransformer.call(attrs))
+          edition.book_id = attrs["book_id"]
+          edition.save!
+          LegacyIdMap.record(model: model_key, legacy_id: attrs["id"], new_id: edition.id)
+        end
+      end
+
+      # Set each book's default_edition_id to its most-popular edition (popularity
+      # desc, nulls last, id asc), for books that have editions only. Set-based SQL
+      # bypasses AR callbacks (no SearchIndexRequest flood — finalize runs OUTSIDE
+      # the without_search_indexing block) and is idempotent. Editionless books
+      # keep default_edition_id NULL (no synthesis).
+      def finalize
+        Books::Book.connection.execute(<<~SQL)
+          UPDATE books_books b
+          SET default_edition_id = e.id
+          FROM (
+            SELECT DISTINCT ON (book_id) id, book_id
+            FROM books_editions
+            ORDER BY book_id, popularity DESC NULLS LAST, id ASC
+          ) e
+          WHERE e.book_id = b.id
+        SQL
+      end
+    end
+  end
+end

--- a/web-app/app/lib/services/books_migration/edition_migrator.rb
+++ b/web-app/app/lib/services/books_migration/edition_migrator.rb
@@ -31,7 +31,9 @@ module Services
       # desc, nulls last, id asc), for books that have editions only. Set-based SQL
       # bypasses AR callbacks (no SearchIndexRequest flood — finalize runs OUTSIDE
       # the without_search_indexing block) and is idempotent. Editionless books
-      # keep default_edition_id NULL (no synthesis).
+      # keep default_edition_id NULL (no synthesis). Authoritative: recomputes on
+      # every run (meant for a pre-launch cutover), so re-running tracks the
+      # current most-popular edition rather than preserving a hand-picked default.
       def finalize
         Books::Book.connection.execute(<<~SQL)
           UPDATE books_books b

--- a/web-app/app/lib/services/books_migration/edition_transformer.rb
+++ b/web-app/app/lib/services/books_migration/edition_transformer.rb
@@ -1,0 +1,55 @@
+module Services
+  module BooksMigration
+    # Legacy `editions` row -> new Books::Edition attributes. PURE (String-keyed
+    # hash in -> symbol-keyed attrs out, no DB). `book_id` (direct passthrough)
+    # and `language_id` (no legacy source) are handled by the migrator. `edition_type`
+    # is omitted so the model default (:standard) applies. `book_binding` is re-encoded
+    # to the NEW enum BY SYMBOL (never by int) — the old and new enums assign different
+    # integers to the same names. `publisher_name` is pulled from the legacy Amazon
+    # PA-API metadata (ByLineInfo.Manufacturer); the full metadata blob is still copied.
+    class EditionTransformer
+      # legacy book_binding int -> legacy symbol
+      LEGACY_BINDING = {
+        0 => :paperback, 1 => :hardcover, 2 => :ebook, 3 => :audible,
+        4 => :mass_market_paperback, 5 => :audio, 6 => :library_binding,
+        7 => :collectable, 8 => :leather_bound, 9 => :other
+      }.freeze
+
+      # legacy symbol -> new Books::Edition book_binding symbol
+      BINDING_TO_NEW = {
+        paperback: :paperback, hardcover: :hardcover, ebook: :ebook,
+        audible: :audiobook, mass_market_paperback: :mass_market, audio: :audiobook,
+        library_binding: :library_binding, collectable: :other,
+        leather_bound: :leather_bound, other: :other
+      }.freeze
+
+      PUBLISHER_PATH = ["amazon", "ItemInfo", "ByLineInfo", "Manufacturer", "DisplayValue"].freeze
+
+      def self.call(attrs)
+        {
+          title: attrs["title"],
+          publication_year: attrs["publication_year"],
+          popularity: attrs["popularity"],
+          book_binding: book_binding(attrs["book_binding"]),
+          publisher_name: publisher_name(attrs["metadata"]),
+          metadata: attrs["metadata"] || {}
+        }
+      end
+
+      def self.book_binding(legacy_int)
+        return nil if legacy_int.nil?
+        legacy_sym = LEGACY_BINDING.fetch(legacy_int) do
+          raise "unknown legacy book_binding: #{legacy_int.inspect}"
+        end
+        BINDING_TO_NEW.fetch(legacy_sym)
+      end
+      private_class_method :book_binding
+
+      def self.publisher_name(metadata)
+        return nil unless metadata.is_a?(Hash)
+        metadata.dig(*PUBLISHER_PATH).presence
+      end
+      private_class_method :publisher_name
+    end
+  end
+end

--- a/web-app/app/lib/services/books_migration/edition_transformer.rb
+++ b/web-app/app/lib/services/books_migration/edition_transformer.rb
@@ -47,7 +47,7 @@ module Services
 
       def self.publisher_name(metadata)
         return nil unless metadata.is_a?(Hash)
-        metadata.dig(*PUBLISHER_PATH).presence
+        PUBLISHER_PATH.reduce(metadata) { |node, key| node.is_a?(Hash) ? node[key] : nil }.presence
       end
       private_class_method :publisher_name
     end

--- a/web-app/app/models/books/edition.rb
+++ b/web-app/app/models/books/edition.rb
@@ -9,6 +9,7 @@
 #  page_count       :integer
 #  popularity       :integer
 #  publication_year :integer
+#  publisher_name   :string
 #  subtitle         :string
 #  title            :string
 #  volume_number    :integer

--- a/web-app/app/models/legacy_books/edition.rb
+++ b/web-app/app/models/legacy_books/edition.rb
@@ -1,0 +1,5 @@
+module LegacyBooks
+  class Edition < Record
+    self.table_name = "editions"
+  end
+end

--- a/web-app/db/migrate/20260704204010_add_publisher_name_to_books_editions.rb
+++ b/web-app/db/migrate/20260704204010_add_publisher_name_to_books_editions.rb
@@ -1,0 +1,5 @@
+class AddPublisherNameToBooksEditions < ActiveRecord::Migration[8.1]
+  def change
+    add_column :books_editions, :publisher_name, :string
+  end
+end

--- a/web-app/db/schema.rb
+++ b/web-app/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_04_034424) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_04_204010) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -156,6 +156,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_04_034424) do
     t.integer "page_count"
     t.integer "popularity"
     t.integer "publication_year"
+    t.string "publisher_name"
     t.string "subtitle"
     t.string "title"
     t.datetime "updated_at", null: false

--- a/web-app/lib/tasks/data_migration.rake
+++ b/web-app/lib/tasks/data_migration.rake
@@ -19,6 +19,11 @@ namespace :data_migration do
     pp Services::BooksMigration::BookAuthorMigrator.call
   end
 
+  desc "Migrate legacy editions into books_editions (fresh ids + map; sets default_edition_id)"
+  task editions: :environment do
+    pp Services::BooksMigration::EditionMigrator.call
+  end
+
   desc "Run all Phase-1 migrators in dependency order"
-  task all: [:languages, :authors, :books, :book_authors]
+  task all: [:languages, :authors, :books, :book_authors, :editions]
 end

--- a/web-app/test/fixtures/books/editions.yml
+++ b/web-app/test/fixtures/books/editions.yml
@@ -11,6 +11,7 @@
 #  page_count       :integer
 #  popularity       :integer
 #  publication_year :integer
+#  publisher_name   :string
 #  subtitle         :string
 #  title            :string
 #  volume_number    :integer

--- a/web-app/test/lib/services/books_migration/edition_migrator_test.rb
+++ b/web-app/test/lib/services/books_migration/edition_migrator_test.rb
@@ -67,4 +67,25 @@ class Services::BooksMigration::EditionMigratorTest < ActiveSupport::TestCase
     run_migrator([{"id" => 5006, "book_id" => other.id, "title" => "E", "book_binding" => 0}])
     assert_nil editionless.reload.default_edition_id
   end
+
+  test "finalize prefers a valued popularity over a nil-popularity edition (NULLS LAST)" do
+    book = Books::Book.create!(title: "Nulls Last Parent")
+    run_migrator([
+      {"id" => 5007, "book_id" => book.id, "title" => "NilPop", "popularity" => nil, "book_binding" => 0},
+      {"id" => 5008, "book_id" => book.id, "title" => "ValPop", "popularity" => 5, "book_binding" => 0}
+    ])
+    valued_id = LegacyIdMap.lookup(model: "Books::Edition", legacy_id: 5008)
+    assert_equal valued_id, book.reload.default_edition_id
+  end
+
+  test "finalize breaks equal-popularity ties by lowest edition id" do
+    book = Books::Book.create!(title: "Tiebreak Parent")
+    run_migrator([
+      {"id" => 5009, "book_id" => book.id, "title" => "A", "popularity" => 7, "book_binding" => 0},
+      {"id" => 5010, "book_id" => book.id, "title" => "B", "popularity" => 7, "book_binding" => 0}
+    ])
+    id_5009 = LegacyIdMap.lookup(model: "Books::Edition", legacy_id: 5009)
+    id_5010 = LegacyIdMap.lookup(model: "Books::Edition", legacy_id: 5010)
+    assert_equal [id_5009, id_5010].min, book.reload.default_edition_id
+  end
 end

--- a/web-app/test/lib/services/books_migration/edition_migrator_test.rb
+++ b/web-app/test/lib/services/books_migration/edition_migrator_test.rb
@@ -1,0 +1,70 @@
+require "test_helper"
+
+class Services::BooksMigration::EditionMigratorTest < ActiveSupport::TestCase
+  def run_migrator(rows)
+    migrator = Services::BooksMigration::EditionMigrator.new
+    migrator.stubs(:legacy_each).multiple_yields(*rows.zip)
+    migrator.call
+  end
+
+  test "creates editions with fresh ids, records the id map, sets book_id, and extracts publisher_name" do
+    book = Books::Book.create!(title: "Edition Parent")
+    md = {"amazon" => {"ItemInfo" => {"ByLineInfo" => {"Manufacturer" => {"DisplayValue" => "Penguin"}}}}}
+
+    result = run_migrator([
+      {"id" => 5001, "book_id" => book.id, "title" => "HC", "publication_year" => 1990,
+       "popularity" => 10, "book_binding" => 1, "metadata" => md}
+    ])
+
+    assert result[:success], result[:error]
+    assert_equal 1, result[:data][:count]
+    assert_equal "Books::Edition", result[:data][:model]
+
+    new_id = LegacyIdMap.lookup(model: "Books::Edition", legacy_id: 5001)
+    assert_not_nil new_id
+    edition = Books::Edition.find(new_id)
+    assert_equal book.id, edition.book_id
+    assert_equal "HC", edition.title
+    assert_equal 1990, edition.publication_year
+    assert_equal "hardcover", edition.book_binding
+    assert_equal "standard", edition.edition_type
+    assert_equal "Penguin", edition.publisher_name
+    assert_equal md, edition.metadata
+  end
+
+  test "is idempotent: re-running updates in place without duplicating or remapping" do
+    book = Books::Book.create!(title: "Idem Edition Parent")
+    run_migrator([{"id" => 5002, "book_id" => book.id, "title" => "V1", "book_binding" => 0}])
+    first_id = LegacyIdMap.lookup(model: "Books::Edition", legacy_id: 5002)
+
+    assert_no_difference -> { Books::Edition.count } do
+      run_migrator([{"id" => 5002, "book_id" => book.id, "title" => "V2", "book_binding" => 0}])
+    end
+    assert_equal first_id, LegacyIdMap.lookup(model: "Books::Edition", legacy_id: 5002)
+    assert_equal "V2", Books::Edition.find(first_id).title
+  end
+
+  test "suppresses search indexing during the load" do
+    book = Books::Book.create!(title: "Quiet Edition Parent")
+    assert_no_difference -> { SearchIndexRequest.count } do
+      run_migrator([{"id" => 5003, "book_id" => book.id, "title" => "Q", "book_binding" => nil}])
+    end
+  end
+
+  test "finalize sets default_edition_id to the most-popular edition" do
+    book = Books::Book.create!(title: "Popularity Parent")
+    run_migrator([
+      {"id" => 5004, "book_id" => book.id, "title" => "Low", "popularity" => 1, "book_binding" => 0},
+      {"id" => 5005, "book_id" => book.id, "title" => "High", "popularity" => 99, "book_binding" => 0}
+    ])
+    high_id = LegacyIdMap.lookup(model: "Books::Edition", legacy_id: 5005)
+    assert_equal high_id, book.reload.default_edition_id
+  end
+
+  test "a book with no editions keeps default_edition_id nil" do
+    editionless = Books::Book.create!(title: "Editionless Parent")
+    other = Books::Book.create!(title: "Has Edition")
+    run_migrator([{"id" => 5006, "book_id" => other.id, "title" => "E", "book_binding" => 0}])
+    assert_nil editionless.reload.default_edition_id
+  end
+end

--- a/web-app/test/lib/services/books_migration/edition_transformer_test.rb
+++ b/web-app/test/lib/services/books_migration/edition_transformer_test.rb
@@ -55,4 +55,9 @@ class Services::BooksMigration::EditionTransformerTest < ActiveSupport::TestCase
     assert_nil transform("metadata" => blank)[:publisher_name]
     assert_nil transform("metadata" => nil)[:publisher_name]
   end
+
+  test "publisher_name is nil when an intermediate metadata node is not a hash" do
+    weird = {"amazon" => {"ItemInfo" => {"ByLineInfo" => "unexpected string"}}}
+    assert_nil transform("metadata" => weird)[:publisher_name]
+  end
 end

--- a/web-app/test/lib/services/books_migration/edition_transformer_test.rb
+++ b/web-app/test/lib/services/books_migration/edition_transformer_test.rb
@@ -1,0 +1,58 @@
+require "test_helper"
+
+class Services::BooksMigration::EditionTransformerTest < ActiveSupport::TestCase
+  def transform(overrides = {})
+    Services::BooksMigration::EditionTransformer.call({
+      "title" => "First Edition", "publication_year" => 1937,
+      "popularity" => 42, "book_binding" => 1, "metadata" => {"src" => "x"}
+    }.merge(overrides))
+  end
+
+  test "maps core fields directly" do
+    attrs = transform
+    assert_equal "First Edition", attrs[:title]
+    assert_equal 1937, attrs[:publication_year]
+    assert_equal 42, attrs[:popularity]
+    assert_equal({"src" => "x"}, attrs[:metadata])
+  end
+
+  test "does not emit edition_type, book_id, or language_id" do
+    attrs = transform
+    refute attrs.key?(:edition_type)
+    refute attrs.key?(:book_id)
+    refute attrs.key?(:language_id)
+  end
+
+  test "re-encodes each legacy book_binding to the new symbol by name" do
+    {0 => :paperback, 1 => :hardcover, 2 => :ebook, 3 => :audiobook,
+     4 => :mass_market, 5 => :audiobook, 6 => :library_binding,
+     7 => :other, 8 => :leather_bound, 9 => :other}.each do |legacy_int, new_sym|
+      assert_equal new_sym, transform("book_binding" => legacy_int)[:book_binding],
+        "legacy binding #{legacy_int} should map to #{new_sym}"
+    end
+  end
+
+  test "nil book_binding stays nil" do
+    assert_nil transform("book_binding" => nil)[:book_binding]
+  end
+
+  test "unknown book_binding raises" do
+    assert_raises(RuntimeError) { transform("book_binding" => 99) }
+  end
+
+  test "nil metadata becomes an empty hash (column is NOT NULL)" do
+    assert_equal({}, transform("metadata" => nil)[:metadata])
+  end
+
+  test "extracts publisher_name from the amazon ByLineInfo manufacturer path" do
+    md = {"amazon" => {"ItemInfo" => {"ByLineInfo" => {"Manufacturer" => {"DisplayValue" => "Random House"}}}}}
+    assert_equal "Random House", transform("metadata" => md)[:publisher_name]
+  end
+
+  test "publisher_name is nil when the manufacturer path is absent, blank, or metadata is nil" do
+    assert_nil transform("metadata" => {"amazon" => {"ItemInfo" => {}}})[:publisher_name]
+    blank = {"amazon" => {"ItemInfo" => {"ByLineInfo" => {"Manufacturer" => {"DisplayValue" => ""}}}}}
+    assert_nil transform("metadata" => blank)[:publisher_name]
+    assert_nil transform("metadata" => nil)[:publisher_name]
+  end
+end

--- a/web-app/test/models/books/edition_test.rb
+++ b/web-app/test/models/books/edition_test.rb
@@ -11,6 +11,7 @@ require "test_helper"
 #  page_count       :integer
 #  popularity       :integer
 #  publication_year :integer
+#  publisher_name   :string
 #  subtitle         :string
 #  title            :string
 #  volume_number    :integer


### PR DESCRIPTION
## Editions migration (Phase 1b increment)

Migrates legacy `editions` → `books_editions` on top of the merged Phase 1a/1b ETL framework, and sets `default_edition_id` on the already-migrated books. Spec: `docs/superpowers/specs/2026-07-04-books-editions-migration-design.md` · Plan: `docs/superpowers/plans/2026-07-04-books-editions-migration.md`.

### What's in it
- **`publisher_name` column** (`2f3911d`) on `books_editions`.
- **`EditionTransformer`** (`c706818`, pure): re-encodes the legacy `book_binding` integer to the new enum **by symbol** (the old and new enums assign different ints to the same names — a naive int copy would silently mislabel 66,874 paperbacks as hardcovers); extracts `publisher_name` from the legacy Amazon metadata.
- **`LegacyBooks::Edition` + `EditionMigrator`** (`2111eec`): fresh ids + `LegacyIdMap("Books::Edition")` as the dedup key (per-row transaction for crash-safety), `book_id` direct passthrough, persists `publisher_name` while preserving the full `metadata` blob; `finalize` sets `default_edition_id` to each book's most-popular edition via one raw set-based `UPDATE`.
- **Orchestrator wiring** (`cf19af5`): `data_migration:editions`, `:all`.

### publisher_name
The legacy `metadata` is an Amazon PA-API v5 blob. The publisher lives at `amazon.ItemInfo.ByLineInfo.Manufacturer.DisplayValue` — present on **144,112 of 148,296 editions (97%)** with clean values ("Random House Publishing Group", "Modern Library Inc", …). Extracted via a nil-safe walk (`.presence`, no Brand fallback); the full metadata is still copied through.

### default_edition_id
69% of books (87,536) have **no** legacy edition, so we do **not** synthesize placeholder editions: `default_edition_id` is set (to the most-popular edition, `popularity DESC NULLS LAST, id ASC`) only for the 38,668 books that have editions; the rest stay `NULL` (the FK is nullable). The `finalize` UPDATE is raw SQL to bypass AR callbacks — `Books::Book` includes `SearchIndexable` and `finalize` runs outside `without_search_indexing`, so an AR update would flood the search-index queue.

### Verification
- Full suite: **4363 runs, 11393 assertions, 0 failures, 0 errors, 0 skips**; `standardrb` clean.
- Real-DB end-to-end run: `EditionMigrator.call` → `{success: true, count: 148296}`; `Books::Edition.count == 148296`; `LegacyIdMap.where(model: "Books::Edition").count == 148296`; `Books::Book.where.not(default_edition_id: nil).count == 38668`; `Books::Edition.where.not(publisher_name: nil).count == 144112`. Pre-run orphan-book_id scan: 0. Search suppression held (0 new `Books::Book` index requests from the run).

### Out of scope (per parent design)
Identifiers (`ol_edition_id`, `identifiers`/`flat_identifiers` jsonb), `book_versions`, edition `language_id` (no legacy source), `description` (always blank in legacy).

> Note: the e2e run wrote 148,296 editions to the **dev** database by design (sets up dev; owner resets before the real import). Test DB untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
