### PR TITLE
Migrate legacy ISBN family to work-level identifiers

### DIFF
--- a/docs/superpowers/plans/2026-07-06-books-isbn-identifiers-migration.md
+++ b/docs/superpowers/plans/2026-07-06-books-isbn-identifiers-migration.md
@@ -1,0 +1,508 @@
+# Books ISBN Identifiers Migration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Migrate the deferred legacy ISBN family (`book_identifiers` types 1-4 + `editions.identifiers` jsonb) into work-level `Identifier` rows on `Books::Book`, deduped on the identifier natural key.
+
+**Architecture:** Add four `books_work_*` ISBN-family enum values to `Identifier` (code-only, no DB migration). Extend the existing `BookIdentifierMigrator` to map `book_identifiers` types 1-4, and add a new `EditionIsbnIdentifierMigrator` that folds each legacy edition's `identifiers` jsonb up to its parent `Books::Book`. Both reuse the per-row `IdentifierMigrator` base (`find_or_create_by!` on the natural key → automatic cross-source/cross-run dedup + fail-loud on a missing book). A shared pure `asin_identifier_type` helper reclassifies ISBN-10-shaped ASINs to isbn10.
+
+**Tech Stack:** Rails 8, Minitest + Mocha, PostgreSQL. Legacy read-only replica via `LegacyBooks::Record`.
+
+**Design doc:** `docs/superpowers/specs/2026-07-06-books-isbn-identifiers-migration-design.md`
+
+## Global Constraints
+
+- Run **all** Rails commands from `web-app/` (`cd web-app` first).
+- Lint with `bundle exec standardrb` (NOT rubocop); security scan `bin/brakeman --no-pager`. CI runs `bin/rails db:test:prepare test test:system`.
+- **No DB migration** — `identifier_type` is already an `integer` column; enum values are a pure model edit.
+- Namespace all migration code under `Services::BooksMigration`; mirror the namespace in tests (`class Services::BooksMigration::...Test`).
+- **Fail loud on a missing prerequisite/FK** — a `book_id` with no migrated `Books::Book` must abort the run naming the offending legacy id (inherited free from `IdentifierMigrator`'s `find_or_create_by!` + `Identifier`'s `belongs_to :identifiable` presence validation + the `Migrator` base's per-row rescue). Never silently drop.
+- **Faithful values** — strip surrounding whitespace, skip blanks (both handled by `upsert_identifier`); no ISBN checksum validation, no reformatting.
+- Dedup is on the `Identifier` natural key `(identifiable_type, identifier_type, value, identifiable_id)` via `find_or_create_by!`.
+- Enum slot assignment (final): `books_work_isbn13: 5`, `books_work_isbn10: 6`, `books_work_asin: 7`, `books_work_ean13: 8`.
+
+---
+
+## File Structure
+
+- **Modify** `web-app/app/models/identifier.rb` — add 4 enum values (Task 1).
+- **Modify** `web-app/app/lib/services/books_migration/identifier_migrator.rb` — add `ISBN10_SHAPE` + pure `asin_identifier_type` class method (Task 1).
+- **Modify** `web-app/test/models/identifier_test.rb` — assert the new enum values (Task 1).
+- **Modify** `web-app/test/lib/services/books_migration/identifier_migrator_test.rb` — unit-test `asin_identifier_type` (Task 1).
+- **Modify** `web-app/app/lib/services/books_migration/book_identifier_migrator.rb` — map types 1-4 (Task 2).
+- **Modify** `web-app/test/lib/services/books_migration/book_identifier_migrator_test.rb` — flip the "deferred" test; add type/asin/fail-loud tests (Task 2).
+- **Create** `web-app/app/lib/services/books_migration/edition_isbn_identifier_migrator.rb` — jsonb → work-level (Task 3).
+- **Create** `web-app/test/lib/services/books_migration/edition_isbn_identifier_migrator_test.rb` (Task 3).
+- **Modify** `web-app/lib/tasks/data_migration.rake` — append the new migrator to `:identifiers` (Task 3).
+
+---
+
+## Task 1: Enum values + shared ASIN-shape helper
+
+**Files:**
+- Modify: `web-app/app/models/identifier.rb`
+- Modify: `web-app/app/lib/services/books_migration/identifier_migrator.rb`
+- Test: `web-app/test/models/identifier_test.rb`
+- Test: `web-app/test/lib/services/books_migration/identifier_migrator_test.rb`
+
+**Interfaces:**
+- Produces (used by Tasks 2 & 3):
+  - `Identifier#identifier_type` accepts `:books_work_isbn13` (5), `:books_work_isbn10` (6), `:books_work_asin` (7), `:books_work_ean13` (8).
+  - `Services::BooksMigration::IdentifierMigrator.asin_identifier_type(value) -> Symbol` — returns `:books_work_isbn10` if `value` (stripped) matches `/\A\d{9}[\dX]\z/i`, else `:books_work_asin`.
+
+- [ ] **Step 1: Write the failing enum test**
+
+Add to `web-app/test/models/identifier_test.rb` (inside the existing `class IdentifierTest`):
+
+```ruby
+  test "defines work-level ISBN-family identifier types at slots 5-8" do
+    assert_equal 5, Identifier.identifier_types["books_work_isbn13"]
+    assert_equal 6, Identifier.identifier_types["books_work_isbn10"]
+    assert_equal 7, Identifier.identifier_types["books_work_asin"]
+    assert_equal 8, Identifier.identifier_types["books_work_ean13"]
+  end
+```
+
+- [ ] **Step 2: Write the failing helper test**
+
+Add to `web-app/test/lib/services/books_migration/identifier_migrator_test.rb` (inside the existing class, after the `strip_openlibrary_key` tests):
+
+```ruby
+  test "asin_identifier_type maps an ISBN-10-shaped value to isbn10" do
+    assert_equal :books_work_isbn10, M.asin_identifier_type("0375755349")
+    assert_equal :books_work_isbn10, M.asin_identifier_type("037575534X")
+    assert_equal :books_work_isbn10, M.asin_identifier_type("037575534x")
+    assert_equal :books_work_isbn10, M.asin_identifier_type("  0375755349  ")
+  end
+
+  test "asin_identifier_type keeps a real Amazon (Kindle) ASIN as asin" do
+    assert_equal :books_work_asin, M.asin_identifier_type("B01K0T9772")
+    assert_equal :books_work_asin, M.asin_identifier_type("B09LVX2Y9V")
+  end
+
+  test "asin_identifier_type defaults blank/short/long values to asin" do
+    assert_equal :books_work_asin, M.asin_identifier_type(nil)
+    assert_equal :books_work_asin, M.asin_identifier_type("")
+    assert_equal :books_work_asin, M.asin_identifier_type("12345")
+    assert_equal :books_work_asin, M.asin_identifier_type("9780375755347")
+  end
+```
+
+- [ ] **Step 3: Run both tests to verify they fail**
+
+Run: `bin/rails test test/models/identifier_test.rb test/lib/services/books_migration/identifier_migrator_test.rb`
+Expected: FAIL — enum keys return `nil`; `NoMethodError: undefined method 'asin_identifier_type'`.
+
+- [ ] **Step 4: Add the enum values**
+
+In `web-app/app/models/identifier.rb`, insert the four values immediately after `books_work_librarything_id: 4,` (keep the blank line before the `# Books - Edition level` comment):
+
+```ruby
+    books_work_librarything_id: 4,
+    books_work_isbn13: 5,
+    books_work_isbn10: 6,
+    books_work_asin: 7,
+    books_work_ean13: 8,
+
+    # Books - Edition level (Books::Edition)
+```
+
+- [ ] **Step 5: Add the shared helper**
+
+In `web-app/app/lib/services/books_migration/identifier_migrator.rb`, add the constant and class method inside `class IdentifierMigrator`, right after the existing `strip_openlibrary_key` method:
+
+```ruby
+      # ISBN-10 shape: 10 chars, first 9 digits, last a digit or X (check digit).
+      # Legacy Amazon "asin" values are ISBN-10 for print books but "B0..." codes
+      # for Kindle; the check keys on shape (not "starts with B") so Kindle ASINs,
+      # which have letters in the first 9 positions, are preserved as ASINs.
+      ISBN10_SHAPE = /\A\d{9}[\dX]\z/i
+
+      # Pure: given a legacy "asin" value, return the work-level identifier_type
+      # symbol. ISBN-10-shaped -> :books_work_isbn10, else -> :books_work_asin.
+      def self.asin_identifier_type(value)
+        ISBN10_SHAPE.match?(value.to_s.strip) ? :books_work_isbn10 : :books_work_asin
+      end
+```
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `bin/rails test test/models/identifier_test.rb test/lib/services/books_migration/identifier_migrator_test.rb`
+Expected: PASS (all tests, including the pre-existing ones).
+
+- [ ] **Step 7: Lint**
+
+Run: `bundle exec standardrb app/models/identifier.rb app/lib/services/books_migration/identifier_migrator.rb`
+Expected: no offenses.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add app/models/identifier.rb app/lib/services/books_migration/identifier_migrator.rb test/models/identifier_test.rb test/lib/services/books_migration/identifier_migrator_test.rb
+git commit -m "Add work-level ISBN-family enum types + ASIN-shape helper"
+```
+
+---
+
+## Task 2: Migrate `book_identifiers` types 1-4
+
+**Files:**
+- Modify: `web-app/app/lib/services/books_migration/book_identifier_migrator.rb`
+- Test: `web-app/test/lib/services/books_migration/book_identifier_migrator_test.rb`
+
+**Interfaces:**
+- Consumes: enum values + `IdentifierMigrator.asin_identifier_type` from Task 1; `upsert_identifier(identifiable_type:, identifiable_id:, identifier_type:, value:)` from the `IdentifierMigrator` base.
+- Produces: `BookIdentifierMigrator` now emits work-level identifiers for legacy `book_identifiers` types 1 (isbn10), 2 (isbn13), 3 (asin→isbn10-or-asin), 4 (ean13), and 5 (goodreads, unchanged).
+
+- [ ] **Step 1: Update the "deferred" test to assert types 1-4 now migrate**
+
+In `web-app/test/lib/services/books_migration/book_identifier_migrator_test.rb`, **delete** the existing test named `"ignores non-goodreads types (isbn/asin/ean deferred)"` (lines ~19-28) and add these tests in its place:
+
+```ruby
+  test "migrates isbn10 (type 1), isbn13 (type 2), ean13 (type 4) as work-level ids" do
+    book = Books::Book.create!(title: "ISBN Book")
+    result = run_migrator([
+      {"id" => 2, "book_id" => book.id, "identifier_type" => 1, "identifier" => "0375755349"},
+      {"id" => 3, "book_id" => book.id, "identifier_type" => 2, "identifier" => "9780375755347"},
+      {"id" => 4, "book_id" => book.id, "identifier_type" => 4, "identifier" => "9780375755347"}
+    ])
+    assert result[:success], result[:error]
+    types = Identifier.where(identifiable: book).pluck(:identifier_type).sort
+    assert_equal ["books_work_ean13", "books_work_isbn10", "books_work_isbn13"], types
+  end
+
+  test "reclassifies an ISBN-10-shaped asin (type 3) as isbn10 but keeps a Kindle asin" do
+    book = Books::Book.create!(title: "ASIN Book")
+    run_migrator([
+      {"id" => 7, "book_id" => book.id, "identifier_type" => 3, "identifier" => "0375755349"},
+      {"id" => 8, "book_id" => book.id, "identifier_type" => 3, "identifier" => "B01K0T9772"}
+    ])
+    pairs = Identifier.where(identifiable: book).pluck(:identifier_type, :value).sort
+    assert_equal [["books_work_asin", "B01K0T9772"], ["books_work_isbn10", "0375755349"]], pairs
+  end
+
+  test "skips an unknown identifier_type" do
+    book = Books::Book.create!(title: "Unknown Type Book")
+    assert_no_difference -> { Identifier.count } do
+      run_migrator([{"id" => 20, "book_id" => book.id, "identifier_type" => 99, "identifier" => "x"}])
+    end
+  end
+
+  test "fails loud when book_id has no migrated Books::Book" do
+    result = run_migrator([{"id" => 9, "book_id" => 999_999, "identifier_type" => 1, "identifier" => "0375755349"}])
+    refute result[:success]
+    assert_match(/legacy id=9/, result[:error])
+  end
+```
+
+- [ ] **Step 2: Run the test file to verify the new tests fail**
+
+Run: `bin/rails test test/lib/services/books_migration/book_identifier_migrator_test.rb`
+Expected: FAIL — types 1-4 currently produce no identifiers (the migrator only handles type 5), so the type-mapping assertions fail.
+
+- [ ] **Step 3: Rewrite the migrator to map all handled types**
+
+Replace the entire body of `web-app/app/lib/services/books_migration/book_identifier_migrator.rb` with:
+
+```ruby
+module Services
+  module BooksMigration
+    # Legacy book_identifiers -> work-level Identifiers on Books::Book. book_id is
+    # preserved, so it is the new Books::Book id directly. Handles the whole legacy
+    # ISBN family plus goodreads:
+    #   1 isbn10, 2 isbn13, 4 ean13, 5 goodreads -> fixed types;
+    #   3 asin    -> isbn10 if ISBN-10-shaped, else asin (see asin_identifier_type).
+    # Values dedupe on the identifier natural key (find_or_create_by!), so a value
+    # also present in editions.identifiers collapses to one row.
+    class BookIdentifierMigrator < IdentifierMigrator
+      TYPE_MAP = {
+        1 => :books_work_isbn10,
+        2 => :books_work_isbn13,
+        4 => :books_work_ean13,
+        5 => :books_work_goodreads_id
+      }.freeze
+      ASIN_TYPE = 3
+
+      private
+
+      def legacy_model
+        LegacyBooks::BookIdentifier
+      end
+
+      def model_key
+        "Identifier (book_identifiers)"
+      end
+
+      def upsert_row(attrs)
+        value = attrs["identifier"]
+        legacy_type = attrs["identifier_type"]
+        identifier_type =
+          (legacy_type == ASIN_TYPE) ? self.class.asin_identifier_type(value) : TYPE_MAP[legacy_type]
+        return if identifier_type.nil?
+        upsert_identifier(
+          identifiable_type: "Books::Book",
+          identifiable_id: attrs["book_id"],
+          identifier_type: identifier_type,
+          value: value
+        )
+      end
+    end
+  end
+end
+```
+
+- [ ] **Step 4: Run the test file to verify it passes**
+
+Run: `bin/rails test test/lib/services/books_migration/book_identifier_migrator_test.rb`
+Expected: PASS (new tests + the retained goodreads, idempotency, and search-suppression tests).
+
+- [ ] **Step 5: Lint**
+
+Run: `bundle exec standardrb app/lib/services/books_migration/book_identifier_migrator.rb test/lib/services/books_migration/book_identifier_migrator_test.rb`
+Expected: no offenses.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/lib/services/books_migration/book_identifier_migrator.rb test/lib/services/books_migration/book_identifier_migrator_test.rb
+git commit -m "Migrate book_identifiers ISBN/ASIN/EAN types to work-level identifiers"
+```
+
+---
+
+## Task 3: `EditionIsbnIdentifierMigrator` (edition jsonb → work-level) + orchestration
+
+**Files:**
+- Create: `web-app/app/lib/services/books_migration/edition_isbn_identifier_migrator.rb`
+- Create: `web-app/test/lib/services/books_migration/edition_isbn_identifier_migrator_test.rb`
+- Modify: `web-app/lib/tasks/data_migration.rake`
+
+**Interfaces:**
+- Consumes: enum values + `IdentifierMigrator.asin_identifier_type` from Task 1; `upsert_identifier(...)` from the base; `LegacyBooks::Edition`.
+- Produces: `Services::BooksMigration::EditionIsbnIdentifierMigrator.call` — reads legacy `editions`, folds each edition's `identifiers` jsonb up to its parent `Books::Book` (via preserved `book_id`) as work-level identifiers.
+
+- [ ] **Step 1: Write the failing test file**
+
+Create `web-app/test/lib/services/books_migration/edition_isbn_identifier_migrator_test.rb`:
+
+```ruby
+require "test_helper"
+
+class Services::BooksMigration::EditionIsbnIdentifierMigratorTest < ActiveSupport::TestCase
+  def run_migrator(rows)
+    m = Services::BooksMigration::EditionIsbnIdentifierMigrator.new
+    m.stubs(:legacy_each).multiple_yields(*rows.zip)
+    m.call
+  end
+
+  test "migrates edition jsonb isbn/ean arrays as work-level identifiers on the book" do
+    book = Books::Book.create!(title: "Ed ISBN Book")
+    result = run_migrator([{"id" => 100, "book_id" => book.id,
+      "identifiers" => {"isbn_10" => ["0375755349"], "isbn_13" => ["9780375755347"], "ean" => ["9780375755347"], "asin" => ""}}])
+    assert result[:success], result[:error]
+    types = Identifier.where(identifiable: book).pluck(:identifier_type).sort
+    assert_equal ["books_work_ean13", "books_work_isbn10", "books_work_isbn13"], types
+  end
+
+  test "fans out a multi-valued array into one identifier per value" do
+    book = Books::Book.create!(title: "Multi EAN Book")
+    run_migrator([{"id" => 101, "book_id" => book.id,
+      "identifiers" => {"ean" => ["9780375755347", "9781234567897"]}}])
+    assert_equal 2, Identifier.where(identifiable: book, identifier_type: :books_work_ean13).count
+  end
+
+  test "reclassifies an ISBN-10-shaped asin and keeps a Kindle asin" do
+    b1 = Books::Book.create!(title: "Phys Ed")
+    b2 = Books::Book.create!(title: "Kindle Ed")
+    run_migrator([
+      {"id" => 102, "book_id" => b1.id, "identifiers" => {"asin" => "0375755349"}},
+      {"id" => 103, "book_id" => b2.id, "identifiers" => {"asin" => "B09LVX2Y9V"}}
+    ])
+    assert_equal "books_work_isbn10", Identifier.find_by(identifiable: b1).identifier_type
+    assert_equal "books_work_asin", Identifier.find_by(identifiable: b2).identifier_type
+  end
+
+  test "handles empty, nil, and non-hash identifiers without error" do
+    book = Books::Book.create!(title: "Empty Ed Book")
+    assert_no_difference -> { Identifier.count } do
+      result = run_migrator([
+        {"id" => 104, "book_id" => book.id, "identifiers" => {}},
+        {"id" => 105, "book_id" => book.id, "identifiers" => nil},
+        {"id" => 106, "book_id" => book.id, "identifiers" => {"isbn_10" => [], "asin" => ""}}
+      ])
+      assert result[:success], result[:error]
+    end
+  end
+
+  test "dedupes against an identifier already created by another source" do
+    book = Books::Book.create!(title: "Dedup Ed Book")
+    Identifier.create!(identifiable: book, identifier_type: :books_work_isbn13, value: "9780375755347")
+    assert_no_difference -> { Identifier.count } do
+      run_migrator([{"id" => 107, "book_id" => book.id, "identifiers" => {"isbn_13" => ["9780375755347"]}}])
+    end
+  end
+
+  test "is idempotent on rerun" do
+    book = Books::Book.create!(title: "Idem Ed Book")
+    rows = [{"id" => 108, "book_id" => book.id, "identifiers" => {"isbn_10" => ["0375755349"]}}]
+    run_migrator(rows)
+    assert_no_difference -> { Identifier.count } do
+      run_migrator(rows)
+    end
+  end
+
+  test "suppresses search indexing during the load" do
+    book = Books::Book.create!(title: "Quiet Ed Book")
+    assert_no_difference -> { SearchIndexRequest.count } do
+      run_migrator([{"id" => 109, "book_id" => book.id, "identifiers" => {"isbn_10" => ["0375755349"]}}])
+    end
+  end
+
+  test "fails loud when book_id has no migrated Books::Book" do
+    result = run_migrator([{"id" => 110, "book_id" => 999_999, "identifiers" => {"isbn_10" => ["0375755349"]}}])
+    refute result[:success]
+    assert_match(/legacy id=110/, result[:error])
+  end
+end
+```
+
+- [ ] **Step 2: Run the test file to verify it fails**
+
+Run: `bin/rails test test/lib/services/books_migration/edition_isbn_identifier_migrator_test.rb`
+Expected: FAIL — `NameError: uninitialized constant Services::BooksMigration::EditionIsbnIdentifierMigrator`.
+
+- [ ] **Step 3: Create the migrator**
+
+Create `web-app/app/lib/services/books_migration/edition_isbn_identifier_migrator.rb`:
+
+```ruby
+module Services
+  module BooksMigration
+    # Legacy editions.identifiers (jsonb) -> work-level ISBN-family Identifiers on
+    # the parent Books::Book. Editions are only READ here; each edition's ISBNs are
+    # folded up to its book (edition.book_id is preserved = the Books::Book id).
+    # jsonb keys isbn_10/isbn_13/ean are arrays (one identifier per element); asin
+    # is a single string reclassified by shape. Values dedupe on the identifier
+    # natural key, so overlap with book_identifiers collapses to one row.
+    class EditionIsbnIdentifierMigrator < IdentifierMigrator
+      ARRAY_KEYS = {
+        "isbn_10" => :books_work_isbn10,
+        "isbn_13" => :books_work_isbn13,
+        "ean" => :books_work_ean13
+      }.freeze
+
+      private
+
+      def legacy_model
+        LegacyBooks::Edition
+      end
+
+      def model_key
+        "Identifier (edition ISBN)"
+      end
+
+      def upsert_row(attrs)
+        ids = attrs["identifiers"]
+        return unless ids.is_a?(Hash)
+        book_id = attrs["book_id"]
+
+        ARRAY_KEYS.each do |key, identifier_type|
+          Array(ids[key]).each do |value|
+            upsert_identifier(
+              identifiable_type: "Books::Book",
+              identifiable_id: book_id,
+              identifier_type: identifier_type,
+              value: value.to_s.strip
+            )
+          end
+        end
+
+        Array(ids["asin"]).each do |value|
+          stripped = value.to_s.strip
+          upsert_identifier(
+            identifiable_type: "Books::Book",
+            identifiable_id: book_id,
+            identifier_type: self.class.asin_identifier_type(stripped),
+            value: stripped
+          )
+        end
+      end
+    end
+  end
+end
+```
+
+- [ ] **Step 4: Run the test file to verify it passes**
+
+Run: `bin/rails test test/lib/services/books_migration/edition_isbn_identifier_migrator_test.rb`
+Expected: PASS (all 8 tests).
+
+- [ ] **Step 5: Wire the migrator into the rake orchestrator**
+
+In `web-app/lib/tasks/data_migration.rake`, update the `:identifiers` task — change the `desc` and append the new migrator call after `EditionIdentifierMigrator`:
+
+```ruby
+  desc "Migrate legacy identifiers (goodreads + openlibrary + ISBN family) into identifiers"
+  task identifiers: :environment do
+    pp Services::BooksMigration::BookIdentifierMigrator.call
+    pp Services::BooksMigration::BookWorkIdentifierMigrator.call
+    pp Services::BooksMigration::AuthorIdentifierMigrator.call
+    pp Services::BooksMigration::EditionIdentifierMigrator.call
+    pp Services::BooksMigration::EditionIsbnIdentifierMigrator.call
+  end
+```
+
+(The `:all` task already depends on `:identifiers`; no change there.)
+
+- [ ] **Step 6: Lint**
+
+Run: `bundle exec standardrb app/lib/services/books_migration/edition_isbn_identifier_migrator.rb test/lib/services/books_migration/edition_isbn_identifier_migrator_test.rb lib/tasks/data_migration.rake`
+Expected: no offenses.
+
+- [ ] **Step 7: Run the whole migration test directory + brakeman**
+
+Run: `bin/rails test test/lib/services/books_migration/ test/models/identifier_test.rb`
+Expected: PASS (all migration + identifier tests).
+
+Run: `bin/brakeman --no-pager -q`
+Expected: no new warnings.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add app/lib/services/books_migration/edition_isbn_identifier_migrator.rb test/lib/services/books_migration/edition_isbn_identifier_migrator_test.rb lib/tasks/data_migration.rake
+git commit -m "Add EditionIsbnIdentifierMigrator + wire into identifiers orchestrator"
+```
+
+---
+
+## Final verification (controller-run, after all tasks)
+
+Not a subagent task — the controller runs these against the real legacy DB (`the_greatest_books_legacy` on `localhost:6543`) on a dev DB reset to the migrated baseline.
+
+- [ ] Full suite green: `bin/rails test` (from `web-app/`).
+- [ ] `bundle exec standardrb` and `bin/brakeman --no-pager` clean.
+- [ ] Run `bin/rails data_migration:identifiers`; confirm each migrator returns `{success: true}`.
+- [ ] Counts by type non-zero and **stable across a second run** (idempotency): `Identifier.where(identifier_type: [:books_work_isbn10, :books_work_isbn13, :books_work_asin, :books_work_ean13]).group(:identifier_type).count`; `Identifier.count` unchanged on rerun.
+- [ ] Spot-check a known physical book (ISBN-10/13 present as `books_work_isbn10/13`) and a Kindle-only edition (`books_work_asin` present, not misfiled as isbn10).
+- [ ] 0 ISBN-family identifiers point at a nonexistent `Books::Book` (fail-loud held).
+- [ ] `SearchIndexRequest` count unchanged by the run (search suppression held).
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- D1 (work-level only) → both migrators write `identifiable_type: "Books::Book"` (Tasks 2, 3). ✓
+- D2 (both sources, deduped) → Task 2 (book_identifiers) + Task 3 (editions jsonb); dedup via `find_or_create_by!` (dedup test in Task 3 Step 1). ✓
+- D3 (ASIN reclassification by shape, no checksum) → `asin_identifier_type` helper (Task 1) used by both migrators; tests for ISBN-10 / X-check-digit / Kindle / blank. ✓
+- D4 (EAN faithful → ean13) → `TYPE_MAP[4]` and `ARRAY_KEYS["ean"]` both `:books_work_ean13`. ✓
+- D5 (strip, skip blank, no validation) → `value.to_s.strip` + `upsert_identifier` blank guard; no ISBN validation added. ✓
+- D6 (typed jsonb, not flat_identifiers) → Task 3 reads `attrs["identifiers"]`. ✓
+- Enum slots 5-8 (code-only) → Task 1 Step 4, no migration. ✓
+- Orchestration → Task 3 Step 5. ✓
+- Fail-loud → tests in Tasks 2 & 3. ✓
+
+**Placeholder scan:** No TBD/TODO; every code step shows complete code; every command has expected output. ✓
+
+**Type consistency:** `asin_identifier_type` (Task 1) returns the same symbols consumed in Tasks 2 & 3; `upsert_identifier` signature matches the base; enum symbols `:books_work_isbn10/isbn13/asin/ean13` consistent throughout. ✓

--- a/docs/superpowers/specs/2026-07-06-books-isbn-identifiers-migration-design.md
+++ b/docs/superpowers/specs/2026-07-06-books-isbn-identifiers-migration-design.md
@@ -1,0 +1,160 @@
+# Books ISBN Identifiers Migration (work-level ISBN/ASIN/EAN) — Design
+
+**Status:** Approved 2026-07-06.
+**Scope:** One migration increment on top of Phase 1a/1b + editions + identifiers + categories (all merged). Migrate the deferred legacy ISBN family — `book_identifiers` types 1-4 (isbn10/isbn13/asin/ean13, book-level) **and** `editions.identifiers` jsonb (edition-level) — into **work-level** polymorphic `Identifier` rows on `Books::Book`. Adds four `books_work_*` enum values (code-only) and reuses the existing per-row `IdentifierMigrator` pattern.
+**Parent design:** `docs/superpowers/specs/2026-07-03-old-site-data-migration-design.md`.
+**Supersedes** the parent design's tentative "edition-level types attach to the book's default edition" note (§Model-by-model → book_identifiers) — see Decision D1.
+
+## Goal
+
+Preserve every legacy ISBN, ISBN-13, ASIN, and EAN-13 as a work-level `Identifier` on the matching `Books::Book`, drawn from **both** legacy sources and deduped on the identifier natural key, with search suppressed and the load idempotent/re-runnable.
+
+## Decisions (from brainstorming 2026-07-06)
+
+- **D1 — one level, work-level.** All ISBN-family identifiers attach to `Books::Book` (work level), **not** to `Books::Edition`. Rationale: the legacy "merge" feature stuffed all ISBNs/EANs/ASINs into work-level `book_identifiers` because editions were never exposed; 69% of books (74,136 of the 106,174 with ISBNs) have **no edition**, so edition-level placement cannot represent them without synthesizing editions (rejected in the editions increment). Work-level ISBN is also a legitimate permanent **discovery index** ("this work was published under these ISBNs"). Edition-level ISBN population is deferred to a future ISBN-lookup API service — the only component that will have trustworthy edition↔ISBN attribution.
+- **D2 — both sources, deduped.** Feed the work-level identifiers from **both** `book_identifiers` types 1-4 and `editions.identifiers` jsonb (edition ISBNs folded up to their parent `Books::Book`). The two sources are complementary (sampled 150 books: 2,706 book-only values, 1,590 edition-only, 282 shared), so both are needed for zero loss. Dedup is automatic via the identifier natural key.
+- **D3 — reclassify ASIN by ISBN-10 shape.** A legacy `asin` value matching `/\A\d{9}[\dX]\z/i` (10 chars, 9 digits + digit/X) is stored as `books_work_isbn10`; otherwise (real `B0…` Kindle codes, etc.) as `books_work_asin`. ~87% of legacy type-3 "asin" values are actually ISBN-10s; Kindle ASINs (letters in the first 9 chars) never match the shape check and are preserved as ASINs. Shape check only — **no** ISBN-10 checksum validation (a bad-checksum ISBN is still an ISBN, not an ASIN). Reclassification also improves dedup: a physical book's ISBN-10 that appeared as both type-1 and type-3 collapses to one `books_work_isbn10` row.
+- **D4 — EAN faithful.** `ean` / type-4 → `books_work_ean13` verbatim (no folding into isbn13, even though for books EAN-13 == ISBN-13). Keeps the legacy distinction; the same 13-digit number may exist as both `books_work_isbn13` and `books_work_ean13` (different-type rows) — acceptable, owner can dedupe later.
+- **D5 — faithful values.** Strip surrounding whitespace, skip blanks. No ISBN checksum validation, no reformatting. Values are already clean (0 blanks, 0 dashes/spaces in the introspected sample).
+- **D6 — source is the typed jsonb, not `flat_identifiers`.** `editions.flat_identifiers` (text) is an untyped flattened value list and cannot distinguish isbn10/isbn13/asin/ean; the typed `editions.identifiers` jsonb is the source.
+
+## Framework reused (already on `main`)
+
+`Services::BooksMigration::Migrator` base (batched `legacy_each` streaming as String-keyed attribute hashes, idempotent, `without_search_indexing`, per-row error context that names the offending legacy id and hard-aborts). `Services::BooksMigration::IdentifierMigrator` base (`< Migrator`): pure `strip_openlibrary_key`, and `upsert_identifier(identifiable_type:, identifiable_id:, identifier_type:, value:)` = `find_or_create_by!` on the natural key that skips blank values and nil identifiable ids. `LegacyBooks::Record` read-only replica base, `LegacyBooks::BookIdentifier`, `LegacyBooks::Edition`. `data_migration:identifiers` rake task.
+
+The `Identifier` natural key (unique index `index_identifiers_on_lookup_unique`) is `(identifiable_type, identifier_type, value, identifiable_id)` → this is what gives cross-source and cross-run dedup for free. `Identifier belongs_to :identifiable, polymorphic: true` with `validates :identifiable, presence: true` → an `identifiable_id` with no migrated `Books::Book` fails validation and hard-aborts the run (fail-loud, consistent with `BookMigrator#remap_language` / `CategoryItemMigrator`). No FK exists on the polymorphic column, so the per-row `find_or_create_by!` validation is what enforces this — a reason **not** to switch to bulk upsert without an explicit id-preload guard.
+
+## Legacy data (local restore, introspected 2026-07-06)
+
+`book_identifiers` (columns: `id, identifier, identifier_type, book_id, created_at, updated_at` — **only `book_id`, no `edition_id`**):
+
+| `identifier_type` | meaning | rows | this pass |
+|---|---|---|---|
+| 1 | isbn10 | 127,729 | → `books_work_isbn10` |
+| 2 | isbn13 | 128,801 | → `books_work_isbn13` |
+| 3 | asin | 10,329 | → `books_work_isbn10` (if ISBN-10-shaped) else `books_work_asin` |
+| 4 | ean13 | 315 | → `books_work_ean13` |
+| 5 | goodreads | 154,524 | already migrated (unchanged) → `books_work_goodreads_id` |
+
+Types 1-4 = **267,174** rows across **106,174** distinct books; **74,136** of those books have **no edition** (only 32,038 do). Type-3 sample: ~13% start with `B` (real Kindle ASIN), ~87% look like ISBN-10. Values: 0 blank, 0 with dash/space.
+
+`editions.identifiers` (jsonb, present on all 148,296 editions; keys `isbn_10`/`isbn_13`/`ean` are **arrays**, `asin` is a **string**):
+
+| jsonb key | shape | this pass |
+|---|---|---|
+| `isbn_10` | Array | → `books_work_isbn10` (one row per element) |
+| `isbn_13` | Array | → `books_work_isbn13` |
+| `ean` | Array | → `books_work_ean13` |
+| `asin` | String | → `books_work_isbn10` (if ISBN-10-shaped) else `books_work_asin` |
+
+Multi-valued arrays occur (sampled 21,475 editions: 543 with >1 ean, 114 with >1 isbn_10, 2 with >1 isbn_13). Est. ~2.1 values/edition → **~311k** edition-sourced values (pre-dedup). Every legacy `edition.book_id` resolves to a migrated `Books::Book` (all 148,296 editions migrated with `book_id` passthrough) — fail-loud is a safety net, not an expected path.
+
+## Schema change (code-only, no DB migration)
+
+`identifier_type` is already an `integer` column. Add four values to `Identifier`'s enum in the free work-level slots (existing `books_work_*` use 0-4):
+
+```ruby
+books_work_isbn13: 5,
+books_work_isbn10: 6,
+books_work_asin: 7,
+books_work_ean13: 8,
+```
+
+No migration, no index change (the unique lookup index is type-agnostic). Update the annotated schema comment in `identifier.rb`.
+
+## Source → target implementation
+
+### Shared helper in `IdentifierMigrator` (base)
+
+A pure class method, testable in isolation and shared by both migrators:
+
+```ruby
+ISBN10_SHAPE = /\A\d{9}[\dX]\z/i
+
+# Given a legacy "asin" value, return the work-level identifier_type symbol:
+# ISBN-10-shaped -> :books_work_isbn10, else -> :books_work_asin.
+def self.asin_identifier_type(value)
+  ISBN10_SHAPE.match?(value.to_s.strip) ? :books_work_isbn10 : :books_work_asin
+end
+```
+
+### Migrator 1 — extend `BookIdentifierMigrator` (`book_identifiers` types 1-4)
+
+Currently emits only type-5 (goodreads). Extend `upsert_row` to also map types 1-4 to work-level identifiers on `Books::Book` (`book_id` preserved = direct). Type→symbol:
+
+| type | symbol |
+|---|---|
+| 1 | `:books_work_isbn10` |
+| 2 | `:books_work_isbn13` |
+| 3 | `asin_identifier_type(value)` |
+| 4 | `:books_work_ean13` |
+| 5 | `:books_work_goodreads_id` (unchanged) |
+
+Any other type → skip (defensive). `identifiable_id = attrs["book_id"]`, `value = attrs["identifier"]`. Update the class comment (the "types 1..4 are deferred" note is now fulfilled) and `model_key` (e.g. `"Identifier (book_identifiers)"`).
+
+### Migrator 2 — new `EditionIsbnIdentifierMigrator` (`editions.identifiers` jsonb)
+
+`< IdentifierMigrator`, `legacy_model = LegacyBooks::Edition`, `model_key = "Identifier (edition ISBN)"`. `upsert_row` reads `attrs["identifiers"]` (a Hash from the jsonb column; guard non-Hash/nil), resolves `book_id = attrs["book_id"]` (preserved = the `Books::Book` id directly), and for each value emits a work-level identifier on `Books::Book`:
+
+- `Array(ids["isbn_10"])` → `:books_work_isbn10`
+- `Array(ids["isbn_13"])` → `:books_work_isbn13`
+- `Array(ids["ean"])` → `:books_work_ean13`
+- `Array(ids["asin"])` → `asin_identifier_type(each)` (`Array("B0…")` wraps the string uniformly; `Array(nil)` = `[]`)
+
+Each value: `to_s.strip`, skip blank (handled by `upsert_identifier`). Multi-valued arrays fan out to one `upsert_identifier` call per element. No `LegacyIdMap` needed (book ids preserved; editions are only *read* here, not their new ids).
+
+### Dedup semantics
+
+`upsert_identifier` is `find_or_create_by!` on `(identifiable_type, identifier_type, value, identifiable_id)`. Therefore:
+- The same ISBN present in both `book_identifiers` and an edition's jsonb → one row.
+- The same ISBN across two editions of the same book → one row (both fold to the same `Books::Book`).
+- A physical book's ISBN-10 arriving as both type-1 and (reclassified) type-3 → one `books_work_isbn10` row.
+- A number that is both an `isbn_13` and an `ean` value → **two** rows (`books_work_isbn13` + `books_work_ean13`, different types) — intended (D4).
+
+### Orchestration
+
+`data_migration:identifiers` runs, in order: `BookIdentifierMigrator` (now incl. ISBN), `BookWorkIdentifierMigrator`, `AuthorIdentifierMigrator`, `EditionIdentifierMigrator`, **`EditionIsbnIdentifierMigrator`** (new, appended). `:all` is unchanged (it already includes `:identifiers`). Both new-work migrators require only `books` migrated (already ordered before `identifiers`).
+
+## Performance
+
+~267k + ~311k = ~578k `find_or_create_by!` calls (~4× the proven 154k goodreads run). On a resync (rows already present) each is a single indexed SELECT on the unique index (no `Books::Book` load, since `create!`/validation only fires on insert). Acceptable for a periodic full sync. **Escape hatch (documented, not built):** if a run is too slow, port both to `BulkUpsertMigrator` (batched `upsert_all`, `unique_by: :index_identifiers_on_lookup_unique`, `ON CONFLICT DO NOTHING`) — which then requires (a) in-batch dedup by natural key and (b) a `@known_book_ids` preload that RAISES on an unknown `book_id` (mirroring `CategoryItemMigrator`) to keep fail-loud, since the polymorphic column has no FK.
+
+## Testing (Minitest + Mocha, stub `legacy_each`)
+
+`BookIdentifierMigrator` test (update existing):
+- **Flip** the "ignores non-goodreads types (isbn/asin/ean deferred)" test → now asserts types 1-4 migrate to the correct work-level types.
+- type 1 → `books_work_isbn10`; type 2 → `books_work_isbn13`; type 4 → `books_work_ean13`.
+- type 3 ISBN-10-shaped (`"0375755349"`) → `books_work_isbn10`; type 3 Kindle (`"B01K0T9772"`) → `books_work_asin`; type 3 with `X` check digit (`"037575534X"`) → `books_work_isbn10`.
+- type 5 still → `books_work_goodreads_id` (regression).
+- idempotent on rerun; search suppression (`SearchIndexRequest` unchanged); fail-loud when `book_id` has no `Books::Book`.
+
+`EditionIsbnIdentifierMigrator` test (new):
+- jsonb with `isbn_10`/`isbn_13`/`ean`/`asin` populated → correct types on the parent `Books::Book` (via `book_id`).
+- multi-valued array (`ean: ["x","y"]`) → two rows.
+- `asin` reclassification (ISBN-10-shaped vs `B0…`).
+- empty/`{}`/nil/non-Hash `identifiers` → no rows, no error.
+- cross-source dedup: a value already inserted by `BookIdentifierMigrator` is not duplicated.
+- idempotent; search suppression; fail-loud on missing `Books::Book`.
+
+`IdentifierMigrator` test (extend): unit-test `asin_identifier_type` (ISBN-10, ISBN-10-with-X, `B0…`, blank/nil, 13-digit).
+
+## E2e verification (controller-run against the real legacy DB)
+
+Reset dev DB to the migrated baseline, run `data_migration:identifiers`, then verify:
+- New work-level ISBN identifier counts by type are non-zero and stable across a second run (idempotency); `Identifier.count` unchanged on rerun.
+- Spot-check a known physical book: its ISBN-10/13 present as `books_work_isbn10/13`; a known Kindle-only book: `books_work_asin` present, not misfiled as isbn10.
+- 0 identifiers point at a nonexistent `Books::Book` (fail-loud held).
+- `pending_index`/`SearchIndexRequest` unchanged (search suppression held).
+- Full test suite green (`bin/rails test`), standardrb + brakeman clean.
+
+## Out of scope
+- Edition-level ISBN identifiers (`books_edition_isbn*`) — deferred to the future ISBN-lookup service (D1).
+- `librarything`, `bookshop_org`, OCLC, wikidata, google identifiers (not in the legacy ISBN family).
+- ISBN normalization/validation/reformatting, cross-type dedup of isbn13-vs-ean13 (D4).
+- Any change to the already-migrated goodreads/openlibrary identifiers.
+
+## References
+- Parent design: `docs/superpowers/specs/2026-07-03-old-site-data-migration-design.md`
+- Prior increment (identifiers): `docs/superpowers/specs/2026-07-04-books-identifiers-migration-design.md` + plan
+- `Identifier` model/enum: `web-app/app/models/identifier.rb`
+- Existing identifier migrators: `web-app/app/lib/services/books_migration/{identifier,book_identifier,book_work_identifier,edition_identifier,author_identifier}_migrator.rb`

--- a/web-app/app/lib/services/books_migration/book_identifier_migrator.rb
+++ b/web-app/app/lib/services/books_migration/book_identifier_migrator.rb
@@ -1,11 +1,20 @@
 module Services
   module BooksMigration
-    # Legacy book_identifiers -> Identifier on Books::Book. This pass migrates only
-    # the goodreads type (legacy identifier_type == 5) as books_work_goodreads_id;
-    # the edition-level ISBN/ASIN/EAN types (1..4) are deferred to a later pass.
-    # book_id is preserved, so it is the new Books::Book id directly.
+    # Legacy book_identifiers -> work-level Identifiers on Books::Book. book_id is
+    # preserved, so it is the new Books::Book id directly. Handles the whole legacy
+    # ISBN family plus goodreads:
+    #   1 isbn10, 2 isbn13, 4 ean13, 5 goodreads -> fixed types;
+    #   3 asin    -> isbn10 if ISBN-10-shaped, else asin (see asin_identifier_type).
+    # Values dedupe on the identifier natural key (find_or_create_by!), so a value
+    # also present in editions.identifiers collapses to one row.
     class BookIdentifierMigrator < IdentifierMigrator
-      GOODREADS_TYPE = 5
+      TYPE_MAP = {
+        1 => :books_work_isbn10,
+        2 => :books_work_isbn13,
+        4 => :books_work_ean13,
+        5 => :books_work_goodreads_id
+      }.freeze
+      ASIN_TYPE = 3
 
       private
 
@@ -14,16 +23,20 @@ module Services
       end
 
       def model_key
-        "Identifier (book goodreads)"
+        "Identifier (book_identifiers)"
       end
 
       def upsert_row(attrs)
-        return unless attrs["identifier_type"] == GOODREADS_TYPE
+        value = attrs["identifier"]
+        legacy_type = attrs["identifier_type"]
+        identifier_type =
+          (legacy_type == ASIN_TYPE) ? self.class.asin_identifier_type(value) : TYPE_MAP[legacy_type]
+        return if identifier_type.nil?
         upsert_identifier(
           identifiable_type: "Books::Book",
           identifiable_id: attrs["book_id"],
-          identifier_type: :books_work_goodreads_id,
-          value: attrs["identifier"]
+          identifier_type: identifier_type,
+          value: value
         )
       end
     end

--- a/web-app/app/lib/services/books_migration/edition_isbn_identifier_migrator.rb
+++ b/web-app/app/lib/services/books_migration/edition_isbn_identifier_migrator.rb
@@ -34,18 +34,17 @@ module Services
               identifiable_type: "Books::Book",
               identifiable_id: book_id,
               identifier_type: identifier_type,
-              value: value.to_s.strip
+              value: value
             )
           end
         end
 
         Array(ids["asin"]).each do |value|
-          stripped = value.to_s.strip
           upsert_identifier(
             identifiable_type: "Books::Book",
             identifiable_id: book_id,
-            identifier_type: self.class.asin_identifier_type(stripped),
-            value: stripped
+            identifier_type: self.class.asin_identifier_type(value),
+            value: value
           )
         end
       end

--- a/web-app/app/lib/services/books_migration/edition_isbn_identifier_migrator.rb
+++ b/web-app/app/lib/services/books_migration/edition_isbn_identifier_migrator.rb
@@ -1,0 +1,54 @@
+module Services
+  module BooksMigration
+    # Legacy editions.identifiers (jsonb) -> work-level ISBN-family Identifiers on
+    # the parent Books::Book. Editions are only READ here; each edition's ISBNs are
+    # folded up to its book (edition.book_id is preserved = the Books::Book id).
+    # jsonb keys isbn_10/isbn_13/ean are arrays (one identifier per element); asin
+    # is a single string reclassified by shape. Values dedupe on the identifier
+    # natural key, so overlap with book_identifiers collapses to one row.
+    class EditionIsbnIdentifierMigrator < IdentifierMigrator
+      ARRAY_KEYS = {
+        "isbn_10" => :books_work_isbn10,
+        "isbn_13" => :books_work_isbn13,
+        "ean" => :books_work_ean13
+      }.freeze
+
+      private
+
+      def legacy_model
+        LegacyBooks::Edition
+      end
+
+      def model_key
+        "Identifier (edition ISBN)"
+      end
+
+      def upsert_row(attrs)
+        ids = attrs["identifiers"]
+        return unless ids.is_a?(Hash)
+        book_id = attrs["book_id"]
+
+        ARRAY_KEYS.each do |key, identifier_type|
+          Array(ids[key]).each do |value|
+            upsert_identifier(
+              identifiable_type: "Books::Book",
+              identifiable_id: book_id,
+              identifier_type: identifier_type,
+              value: value.to_s.strip
+            )
+          end
+        end
+
+        Array(ids["asin"]).each do |value|
+          stripped = value.to_s.strip
+          upsert_identifier(
+            identifiable_type: "Books::Book",
+            identifiable_id: book_id,
+            identifier_type: self.class.asin_identifier_type(stripped),
+            value: stripped
+          )
+        end
+      end
+    end
+  end
+end

--- a/web-app/app/lib/services/books_migration/identifier_migrator.rb
+++ b/web-app/app/lib/services/books_migration/identifier_migrator.rb
@@ -32,6 +32,7 @@ module Services
       # and hard-aborts the run (the per-row error names the offending legacy id;
       # the run is idempotent, so it resumes after the data is corrected).
       def upsert_identifier(identifiable_type:, identifiable_id:, identifier_type:, value:)
+        value = value.to_s.strip
         return if value.blank? || identifiable_id.nil?
         Identifier.find_or_create_by!(
           identifiable_type: identifiable_type,

--- a/web-app/app/lib/services/books_migration/identifier_migrator.rb
+++ b/web-app/app/lib/services/books_migration/identifier_migrator.rb
@@ -12,6 +12,18 @@ module Services
         value.to_s.rpartition("/").last.presence
       end
 
+      # ISBN-10 shape: 10 chars, first 9 digits, last a digit or X (check digit).
+      # Legacy Amazon "asin" values are ISBN-10 for print books but "B0..." codes
+      # for Kindle; the check keys on shape (not "starts with B") so Kindle ASINs,
+      # which have letters in the first 9 positions, are preserved as ASINs.
+      ISBN10_SHAPE = /\A\d{9}[\dX]\z/i
+
+      # Pure: given a legacy "asin" value, return the work-level identifier_type
+      # symbol. ISBN-10-shaped -> :books_work_isbn10, else -> :books_work_asin.
+      def self.asin_identifier_type(value)
+        ISBN10_SHAPE.match?(value.to_s.strip) ? :books_work_isbn10 : :books_work_asin
+      end
+
       private
 
       # The identifiable target (Books::Book/Author/Edition) must already exist —

--- a/web-app/app/models/identifier.rb
+++ b/web-app/app/models/identifier.rb
@@ -28,6 +28,10 @@ class Identifier < ApplicationRecord
     books_work_openlibrary_id: 2,
     books_work_goodreads_id: 3,
     books_work_librarything_id: 4,
+    books_work_isbn13: 5,
+    books_work_isbn10: 6,
+    books_work_asin: 7,
+    books_work_ean13: 8,
 
     # Books - Edition level (Books::Edition)
     books_edition_isbn13: 10,

--- a/web-app/lib/tasks/data_migration.rake
+++ b/web-app/lib/tasks/data_migration.rake
@@ -24,12 +24,13 @@ namespace :data_migration do
     pp Services::BooksMigration::EditionMigrator.call
   end
 
-  desc "Migrate legacy identifiers (goodreads + openlibrary) into identifiers"
+  desc "Migrate legacy identifiers (goodreads + openlibrary + ISBN family) into identifiers"
   task identifiers: :environment do
     pp Services::BooksMigration::BookIdentifierMigrator.call
     pp Services::BooksMigration::BookWorkIdentifierMigrator.call
     pp Services::BooksMigration::AuthorIdentifierMigrator.call
     pp Services::BooksMigration::EditionIdentifierMigrator.call
+    pp Services::BooksMigration::EditionIsbnIdentifierMigrator.call
   end
 
   desc "Migrate legacy categories into Books::Category (fresh ids + map; preserves slug + parent)"

--- a/web-app/test/lib/services/books_migration/book_identifier_migrator_test.rb
+++ b/web-app/test/lib/services/books_migration/book_identifier_migrator_test.rb
@@ -16,15 +16,39 @@ class Services::BooksMigration::BookIdentifierMigratorTest < ActiveSupport::Test
     assert_equal "1079398", idf.value
   end
 
-  test "ignores non-goodreads types (isbn/asin/ean deferred)" do
+  test "migrates isbn10 (type 1), isbn13 (type 2), ean13 (type 4) as work-level ids" do
     book = Books::Book.create!(title: "ISBN Book")
+    result = run_migrator([
+      {"id" => 2, "book_id" => book.id, "identifier_type" => 1, "identifier" => "0375755349"},
+      {"id" => 3, "book_id" => book.id, "identifier_type" => 2, "identifier" => "9780375755347"},
+      {"id" => 4, "book_id" => book.id, "identifier_type" => 4, "identifier" => "9780375755347"}
+    ])
+    assert result[:success], result[:error]
+    types = Identifier.where(identifiable: book).pluck(:identifier_type).sort
+    assert_equal ["books_work_ean13", "books_work_isbn10", "books_work_isbn13"], types
+  end
+
+  test "reclassifies an ISBN-10-shaped asin (type 3) as isbn10 but keeps a Kindle asin" do
+    book = Books::Book.create!(title: "ASIN Book")
+    run_migrator([
+      {"id" => 7, "book_id" => book.id, "identifier_type" => 3, "identifier" => "0375755349"},
+      {"id" => 8, "book_id" => book.id, "identifier_type" => 3, "identifier" => "B01K0T9772"}
+    ])
+    pairs = Identifier.where(identifiable: book).pluck(:identifier_type, :value).sort
+    assert_equal [["books_work_asin", "B01K0T9772"], ["books_work_isbn10", "0375755349"]], pairs
+  end
+
+  test "skips an unknown identifier_type" do
+    book = Books::Book.create!(title: "Unknown Type Book")
     assert_no_difference -> { Identifier.count } do
-      run_migrator([
-        {"id" => 2, "book_id" => book.id, "identifier_type" => 1, "identifier" => "0375755349"},
-        {"id" => 3, "book_id" => book.id, "identifier_type" => 2, "identifier" => "9780375755347"},
-        {"id" => 4, "book_id" => book.id, "identifier_type" => 3, "identifier" => "B01K0T9772"}
-      ])
+      run_migrator([{"id" => 20, "book_id" => book.id, "identifier_type" => 99, "identifier" => "x"}])
     end
+  end
+
+  test "fails loud when book_id has no migrated Books::Book" do
+    result = run_migrator([{"id" => 9, "book_id" => 999_999, "identifier_type" => 1, "identifier" => "0375755349"}])
+    refute result[:success]
+    assert_match(/legacy id=9/, result[:error])
   end
 
   test "is idempotent on the natural key" do

--- a/web-app/test/lib/services/books_migration/book_identifier_migrator_test.rb
+++ b/web-app/test/lib/services/books_migration/book_identifier_migrator_test.rb
@@ -66,4 +66,10 @@ class Services::BooksMigration::BookIdentifierMigratorTest < ActiveSupport::Test
       run_migrator([{"id" => 6, "book_id" => book.id, "identifier_type" => 5, "identifier" => "42"}])
     end
   end
+
+  test "strips surrounding whitespace from the stored value" do
+    book = Books::Book.create!(title: "Whitespace Book")
+    run_migrator([{"id" => 30, "book_id" => book.id, "identifier_type" => 1, "identifier" => "  0375755349  "}])
+    assert_equal "0375755349", Identifier.find_by(identifiable: book).value
+  end
 end

--- a/web-app/test/lib/services/books_migration/edition_isbn_identifier_migrator_test.rb
+++ b/web-app/test/lib/services/books_migration/edition_isbn_identifier_migrator_test.rb
@@ -1,0 +1,78 @@
+require "test_helper"
+
+class Services::BooksMigration::EditionIsbnIdentifierMigratorTest < ActiveSupport::TestCase
+  def run_migrator(rows)
+    m = Services::BooksMigration::EditionIsbnIdentifierMigrator.new
+    m.stubs(:legacy_each).multiple_yields(*rows.zip)
+    m.call
+  end
+
+  test "migrates edition jsonb isbn/ean arrays as work-level identifiers on the book" do
+    book = Books::Book.create!(title: "Ed ISBN Book")
+    result = run_migrator([{"id" => 100, "book_id" => book.id,
+                            "identifiers" => {"isbn_10" => ["0375755349"], "isbn_13" => ["9780375755347"], "ean" => ["9780375755347"], "asin" => ""}}])
+    assert result[:success], result[:error]
+    types = Identifier.where(identifiable: book).pluck(:identifier_type).sort
+    assert_equal ["books_work_ean13", "books_work_isbn10", "books_work_isbn13"], types
+  end
+
+  test "fans out a multi-valued array into one identifier per value" do
+    book = Books::Book.create!(title: "Multi EAN Book")
+    run_migrator([{"id" => 101, "book_id" => book.id,
+                   "identifiers" => {"ean" => ["9780375755347", "9781234567897"]}}])
+    assert_equal 2, Identifier.where(identifiable: book, identifier_type: :books_work_ean13).count
+  end
+
+  test "reclassifies an ISBN-10-shaped asin and keeps a Kindle asin" do
+    b1 = Books::Book.create!(title: "Phys Ed")
+    b2 = Books::Book.create!(title: "Kindle Ed")
+    run_migrator([
+      {"id" => 102, "book_id" => b1.id, "identifiers" => {"asin" => "0375755349"}},
+      {"id" => 103, "book_id" => b2.id, "identifiers" => {"asin" => "B09LVX2Y9V"}}
+    ])
+    assert_equal "books_work_isbn10", Identifier.find_by(identifiable: b1).identifier_type
+    assert_equal "books_work_asin", Identifier.find_by(identifiable: b2).identifier_type
+  end
+
+  test "handles empty, nil, and non-hash identifiers without error" do
+    book = Books::Book.create!(title: "Empty Ed Book")
+    assert_no_difference -> { Identifier.count } do
+      result = run_migrator([
+        {"id" => 104, "book_id" => book.id, "identifiers" => {}},
+        {"id" => 105, "book_id" => book.id, "identifiers" => nil},
+        {"id" => 106, "book_id" => book.id, "identifiers" => {"isbn_10" => [], "asin" => ""}}
+      ])
+      assert result[:success], result[:error]
+    end
+  end
+
+  test "dedupes against an identifier already created by another source" do
+    book = Books::Book.create!(title: "Dedup Ed Book")
+    Identifier.create!(identifiable: book, identifier_type: :books_work_isbn13, value: "9780375755347")
+    assert_no_difference -> { Identifier.count } do
+      run_migrator([{"id" => 107, "book_id" => book.id, "identifiers" => {"isbn_13" => ["9780375755347"]}}])
+    end
+  end
+
+  test "is idempotent on rerun" do
+    book = Books::Book.create!(title: "Idem Ed Book")
+    rows = [{"id" => 108, "book_id" => book.id, "identifiers" => {"isbn_10" => ["0375755349"]}}]
+    run_migrator(rows)
+    assert_no_difference -> { Identifier.count } do
+      run_migrator(rows)
+    end
+  end
+
+  test "suppresses search indexing during the load" do
+    book = Books::Book.create!(title: "Quiet Ed Book")
+    assert_no_difference -> { SearchIndexRequest.count } do
+      run_migrator([{"id" => 109, "book_id" => book.id, "identifiers" => {"isbn_10" => ["0375755349"]}}])
+    end
+  end
+
+  test "fails loud when book_id has no migrated Books::Book" do
+    result = run_migrator([{"id" => 110, "book_id" => 999_999, "identifiers" => {"isbn_10" => ["0375755349"]}}])
+    refute result[:success]
+    assert_match(/legacy id=110/, result[:error])
+  end
+end

--- a/web-app/test/lib/services/books_migration/identifier_migrator_test.rb
+++ b/web-app/test/lib/services/books_migration/identifier_migrator_test.rb
@@ -14,4 +14,23 @@ class Services::BooksMigration::IdentifierMigratorTest < ActiveSupport::TestCase
     assert_nil M.strip_openlibrary_key(nil)
     assert_nil M.strip_openlibrary_key("")
   end
+
+  test "asin_identifier_type maps an ISBN-10-shaped value to isbn10" do
+    assert_equal :books_work_isbn10, M.asin_identifier_type("0375755349")
+    assert_equal :books_work_isbn10, M.asin_identifier_type("037575534X")
+    assert_equal :books_work_isbn10, M.asin_identifier_type("037575534x")
+    assert_equal :books_work_isbn10, M.asin_identifier_type("  0375755349  ")
+  end
+
+  test "asin_identifier_type keeps a real Amazon (Kindle) ASIN as asin" do
+    assert_equal :books_work_asin, M.asin_identifier_type("B01K0T9772")
+    assert_equal :books_work_asin, M.asin_identifier_type("B09LVX2Y9V")
+  end
+
+  test "asin_identifier_type defaults blank/short/long values to asin" do
+    assert_equal :books_work_asin, M.asin_identifier_type(nil)
+    assert_equal :books_work_asin, M.asin_identifier_type("")
+    assert_equal :books_work_asin, M.asin_identifier_type("12345")
+    assert_equal :books_work_asin, M.asin_identifier_type("9780375755347")
+  end
 end

--- a/web-app/test/models/identifier_test.rb
+++ b/web-app/test/models/identifier_test.rb
@@ -266,4 +266,11 @@ class IdentifierTest < ActiveSupport::TestCase
     # Currently the model doesn't strip, but the service does
     assert_equal "  test-mbid-with-spaces  ", identifier.value
   end
+
+  test "defines work-level ISBN-family identifier types at slots 5-8" do
+    assert_equal 5, Identifier.identifier_types["books_work_isbn13"]
+    assert_equal 6, Identifier.identifier_types["books_work_isbn10"]
+    assert_equal 7, Identifier.identifier_types["books_work_asin"]
+    assert_equal 8, Identifier.identifier_types["books_work_ean13"]
+  end
 end


### PR DESCRIPTION
## Summary

Migrates the deferred legacy **ISBN family** into **work-level** polymorphic `Identifier` rows on `Books::Book`, from both legacy sources, deduped. This is the explicitly-deferred follow-up to the merged identifiers increment (#158).

Spec: `docs/superpowers/specs/2026-07-06-books-isbn-identifiers-migration-design.md`
Plan: `docs/superpowers/plans/2026-07-06-books-isbn-identifiers-migration.md`

### The decision (from brainstorming)

The old site's "merge" feature stuffed every ISBN/EAN/ASIN into **work-level** `book_identifiers` because editions were never exposed, and **69% of books (74k) have no edition** — so edition-level placement can't represent them without synthesizing editions (rejected earlier). Therefore **all ISBNs live at work level** on `Books::Book` this pass; real edition-level ISBN attribution is deferred to the future ISBN-lookup API service. Both legacy sources feed it, deduped on the identifier natural key:

- `book_identifiers` types 1-4 (isbn10/isbn13/asin/ean13) — book-level, 267k rows.
- `editions.identifiers` jsonb — edition-level, folded up to the parent book (~311k values).

### Changes

- **Enum (code-only, no DB migration):** `Identifier` gains `books_work_isbn13: 5`, `books_work_isbn10: 6`, `books_work_asin: 7`, `books_work_ean13: 8` (`identifier_type` was already an integer column).
- **`asin_identifier_type` helper** on the `IdentifierMigrator` base: legacy `asin` values that are ISBN-10-shaped (`/\A\d{9}[\dX]\z/i`, shape only — no checksum) are reclassified to `books_work_isbn10`; real Kindle `B0…` codes stay `books_work_asin`.
- **`BookIdentifierMigrator`** extended to map types 1-4 (was goodreads-only).
- **`EditionIsbnIdentifierMigrator`** (new): parses the typed `identifiers` jsonb (not the untyped `flat_identifiers`), fans out array values, attaches to the parent `Books::Book`.
- Both reuse the per-row `IdentifierMigrator` (`find_or_create_by!` → automatic cross-source/cross-run dedup + fail-loud on a missing book, naming the legacy id).
- `value.to_s.strip` centralized in the base `upsert_identifier` (D5 — from final review).

### e2e verification (real legacy DB, dev)

- All 5 identifier migrators `{success:true}`; **+477,792** work-level ISBN identifiers (isbn10 183,980 / isbn13 133,915 / asin 79,105 / ean13 80,792). Total 449,674 → 927,466 (exactly +477,792 — no existing identifier disturbed).
- **Idempotent**: a second full run left counts unchanged.
- **Fail-loud held**: 0 identifiers point at a nonexistent `Books::Book`.
- **Search suppression held**: `SearchIndexRequest` unchanged (4→4).
- **ASIN reclassification correct**: 0 `books_work_asin` values are ISBN-10-shaped (all real `B0…`); Kindle ASINs preserved.
- Spot-check (book #4098) folds multiple editions' ISBNs to the work, keeps a real Kindle ASIN, preserves EAN separately (incl. a genuine non-ISBN EAN).

### Notes / faithful legacy quirks (not bugs)

- **EAN kept separate from ISBN-13** (D4): the same 13-digit book number can appear as both `books_work_isbn13` and `books_work_ean13`.
- **39** `books_work_isbn10` values start with "B" — legacy rows where a `B0…` ASIN was mislabeled under the legacy `isbn_10` field; D3 only reclassifies the ambiguous `asin` field and D5 trusts declared isbn_10 verbatim, so these are faithfully preserved (0.02%).
- Edition-level ISBN identifiers (`books_edition_isbn*`) are intentionally **not** written this pass.

### Tests / CI

Full suite green: **4422 runs, 11526 assertions, 0 failures, 0 errors, 0 skips**. standardrb clean. brakeman unchanged (31 pre-existing warnings, 0 new).

Built via superpowers subagent-driven development (3 tasks, per-task spec+quality review, whole-branch opus review — ready-to-merge, one Minor D5 strip fix applied). The heavy e2e was run by the controller against `the_greatest_books_legacy`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)