### PR TITLE
Migrate legacy links into external_links (Books::Book)

### DIFF
--- a/docs/superpowers/plans/2026-07-08-books-external-links-migration.md
+++ b/docs/superpowers/plans/2026-07-08-books-external-links-migration.md
@@ -1,0 +1,350 @@
+# External Links Migration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Migrate the legacy `links` table (13,404 rows) into the polymorphic `ExternalLink` model, parented to `Books::Book` (preserved ids) with `submitted_by` resolving to the migrated users, inferring `source` from the URL host.
+
+**Architecture:** A per-row ActiveRecord `Migrator` subclass (`ExternalLinkMigrator`) reads each legacy `links` row and upserts an `ExternalLink` via `find_or_initialize_by` on the natural key `[parent_type, parent_id, url]` — no schema change, no unique index needed. Model validations run, so a missing `Books::Book` (required `belongs_to :parent`) or missing user (DB FK on `submitted_by_id`) fails loud, wrapped by the base rescue that names the legacy link id. `source` is inferred from a string-extracted host (never `URI.parse`, which raises on the two non-ASCII Wikipedia URLs).
+
+**Tech Stack:** Rails 8, Minitest + Mocha, PostgreSQL. Reuses `Services::BooksMigration::Migrator` (per-row AR base) and `LegacyBooks::Record` (read-only legacy replica).
+
+## Global Constraints
+
+- Run **all** Rails commands from `web-app/` (`cd web-app` first).
+- Lint with `bundle exec standardrb` (NOT rubocop); must be clean.
+- Namespace: `Services::BooksMigration::` for the migrator; `LegacyBooks::` for the legacy model; tests mirror the namespace (`module Services; module BooksMigration; class ...Test`).
+- **No schema change.** `external_links` already has every needed column and polymorphic `parent`. Do not add an index.
+- **Per-row AR write path** (subclass `Migrator`, not `BulkUpsertMigrator`). Idempotency via `find_or_initialize_by(parent_type:, parent_id:, url:)`.
+- **Fail loud** on a missing FK — never silently drop. Achieved here for free by AR validation (`belongs_to :parent` required) + the DB FK on `submitted_by_id`; the base `Migrator` rescue re-raises naming the legacy link id.
+- Owner decisions baked in: `name` migrated **verbatim**; `link_category` always `:information`; scheme-less URLs **normalized** to `https://`.
+- Preserve legacy `created_at`/`updated_at`.
+- No code comments beyond the one class-level doc comment (house style; see sibling migrators).
+
+## File Structure
+
+- **Create** `web-app/app/models/legacy_books/link.rb` — read-only legacy `links` model (mirrors `legacy_books/user.rb`).
+- **Create** `web-app/app/lib/services/books_migration/external_link_migrator.rb` — the migrator (per-row AR + host/source/url helpers).
+- **Create** `web-app/test/lib/services/books_migration/external_link_migrator_test.rb` — unit tests (stub `legacy_each`).
+- **Modify** `web-app/lib/tasks/data_migration.rake` — add `:external_links` task + insert into `:all`.
+
+---
+
+## Task 1: `LegacyBooks::Link` + `ExternalLinkMigrator` + orchestration
+
+**Files:**
+- Create: `web-app/app/models/legacy_books/link.rb`
+- Create: `web-app/app/lib/services/books_migration/external_link_migrator.rb`
+- Test: `web-app/test/lib/services/books_migration/external_link_migrator_test.rb`
+- Modify: `web-app/lib/tasks/data_migration.rake`
+
+**Interfaces:**
+- Consumes: `Services::BooksMigration::Migrator` (base; provides `call`, `legacy_each`, per-row rescue, `@count`, `without_search_indexing`); `ExternalLink` (target model, `enum :source` + `enum :link_category` both `prefix: true`); `Books::Book`, `User` (parents/submitters).
+- Produces: `Services::BooksMigration::ExternalLinkMigrator.call → {success:, data: {model: "ExternalLink", count:}}` (or `{success: false, error:}`); `LegacyBooks::Link` (read-only, `table_name = "links"`); rake task `data_migration:external_links`.
+
+- [ ] **Step 1: Create the read-only legacy model**
+
+Create `web-app/app/models/legacy_books/link.rb`:
+
+```ruby
+module LegacyBooks
+  class Link < Record
+    self.table_name = "links"
+  end
+end
+```
+
+- [ ] **Step 2: Write the failing test file**
+
+Create `web-app/test/lib/services/books_migration/external_link_migrator_test.rb`:
+
+```ruby
+require "test_helper"
+
+module Services
+  module BooksMigration
+    class ExternalLinkMigratorTest < ActiveSupport::TestCase
+      setup do
+        @book = Books::Book.create!(title: "Link Parent")
+        @user = users(:regular_user)
+      end
+
+      def run_migrator(rows)
+        migrator = ExternalLinkMigrator.new
+        migrator.stubs(:legacy_each).multiple_yields(*rows.zip)
+        migrator.call
+      end
+
+      def legacy_row(overrides = {})
+        {
+          "id" => 1,
+          "name" => "Wikipedia",
+          "url" => "http://en.wikipedia.org/wiki/Test",
+          "user_id" => @user.id,
+          "description" => nil,
+          "book_id" => @book.id,
+          "created_at" => Time.utc(2022, 11, 5, 4, 12, 17),
+          "updated_at" => Time.utc(2022, 11, 5, 4, 12, 17)
+        }.merge(overrides)
+      end
+
+      test "maps a legacy link to a Books::Book-parented ExternalLink" do
+        result = run_migrator([legacy_row])
+
+        assert result[:success], result[:error]
+        assert_equal 1, result[:data][:count]
+        assert_equal "ExternalLink", result[:data][:model]
+
+        link = ExternalLink.find_by(parent_type: "Books::Book", parent_id: @book.id)
+        assert_not_nil link
+        assert_equal @book, link.parent
+        assert_equal @user, link.submitted_by
+        assert_equal "Wikipedia", link.name
+        assert_nil link.description
+        assert_equal "http://en.wikipedia.org/wiki/Test", link.url
+        assert link.public?
+        assert link.link_category_information?
+        assert link.source_wikipedia?
+        assert_nil link.source_name
+      end
+
+      test "preserves legacy created_at/updated_at" do
+        ts = Time.utc(2024, 12, 15, 9, 0, 0)
+        run_migrator([legacy_row("created_at" => ts, "updated_at" => ts)])
+
+        link = ExternalLink.find_by(parent_type: "Books::Book", parent_id: @book.id)
+        assert_equal ts, link.created_at
+        assert_equal ts, link.updated_at
+      end
+
+      test "infers source from the URL host" do
+        cases = {
+          "http://en.wikipedia.org/wiki/A" => "wikipedia",
+          "http://de.wikipedia.org/wiki/B" => "wikipedia",
+          "https://www.goodreads.com/book/show/1" => "goodreads",
+          "http://www.amazon.com/dp/123" => "amazon",
+          "https://bookshop.org/books/x" => "bookshop_org",
+          "http://books.google.com/books?q=x" => "other",
+          "http://www.time.com/x" => "other",
+          "http://www.powells.com/biblio/x" => "other"
+        }
+        rows = cases.keys.each_with_index.map do |url, i|
+          book = Books::Book.create!(title: "Src Parent #{i}")
+          legacy_row("id" => 100 + i, "book_id" => book.id, "url" => url)
+        end
+        result = run_migrator(rows)
+
+        assert result[:success], result[:error]
+        cases.each do |url, expected|
+          link = ExternalLink.find_by(url: url)
+          assert_not_nil link, "no link for #{url}"
+          assert_equal expected, link.source, "wrong source for #{url}"
+        end
+      end
+
+      test "sets source_name to the host for other-source links only" do
+        other_book = Books::Book.create!(title: "Other Parent")
+        run_migrator([
+          legacy_row("id" => 200, "book_id" => other_book.id, "url" => "http://books.google.com/books?q=x"),
+          legacy_row("id" => 201, "url" => "http://en.wikipedia.org/wiki/Y")
+        ])
+
+        other = ExternalLink.find_by(url: "http://books.google.com/books?q=x")
+        assert other.source_other?
+        assert_equal "books.google.com", other.source_name
+
+        wiki = ExternalLink.find_by(url: "http://en.wikipedia.org/wiki/Y")
+        assert wiki.source_wikipedia?
+        assert_nil wiki.source_name
+      end
+
+      test "classifies non-ASCII wikipedia URLs without raising" do
+        url = "http://en.wikipedia.org/wiki/Gödel,_Escher,_Bach"
+        result = run_migrator([legacy_row("url" => url)])
+
+        assert result[:success], result[:error]
+        assert ExternalLink.find_by(url: url).source_wikipedia?
+      end
+
+      test "normalizes scheme-less URLs to https" do
+        result = run_migrator([legacy_row("url" => "en.wikipedia.org/wiki/The_Hunting_of_the_Snark")])
+
+        assert result[:success], result[:error]
+        link = ExternalLink.find_by(parent_type: "Books::Book", parent_id: @book.id)
+        assert_equal "https://en.wikipedia.org/wiki/The_Hunting_of_the_Snark", link.url
+        assert link.source_wikipedia?
+      end
+
+      test "is idempotent on [parent, url]: re-running does not duplicate" do
+        run_migrator([legacy_row])
+
+        assert_no_difference -> { ExternalLink.count } do
+          result = run_migrator([legacy_row])
+          assert result[:success], result[:error]
+          assert_equal 1, result[:data][:count]
+        end
+      end
+
+      test "fails loud naming the legacy id when the book is missing" do
+        missing = Books::Book.maximum(:id).to_i + 999_999
+        result = run_migrator([legacy_row("id" => 4242, "book_id" => missing)])
+
+        refute result[:success]
+        assert_match(/4242/, result[:error])
+      end
+    end
+  end
+end
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `cd web-app && bin/rails test test/lib/services/books_migration/external_link_migrator_test.rb`
+Expected: FAIL — `NameError: uninitialized constant Services::BooksMigration::ExternalLinkMigrator` (the migrator does not exist yet).
+
+- [ ] **Step 4: Implement the migrator**
+
+Create `web-app/app/lib/services/books_migration/external_link_migrator.rb`:
+
+```ruby
+module Services
+  module BooksMigration
+    # Legacy `links` -> polymorphic ExternalLink, parented to Books::Book (preserved
+    # ids), submitted_by -> the migrated user. Per-row AR (find_or_initialize_by on the
+    # natural key [parent, url]) because external_links has no unique index to upsert
+    # against. Validations run, so fail-loud is free: a missing Books::Book fails the
+    # required belongs_to :parent, a missing user hits the submitted_by_id DB FK; the
+    # base rescue names the legacy link id. `source` is inferred from the URL host by
+    # string ops (not URI.parse, which raises on the non-ASCII Wikipedia urls). `name`
+    # is migrated verbatim, `link_category` is always :information, and scheme-less urls
+    # are normalized to https://. Legacy created_at/updated_at are preserved (assigning
+    # non-nil timestamps leaves AR's create-time callback untouched). Idempotent on
+    # [parent, url].
+    class ExternalLinkMigrator < Migrator
+      private
+
+      def legacy_model
+        LegacyBooks::Link
+      end
+
+      def model_key
+        "ExternalLink"
+      end
+
+      def upsert_row(attrs)
+        url = normalize_url(attrs["url"])
+        source = source_for(url)
+        link = ExternalLink.find_or_initialize_by(
+          parent_type: "Books::Book",
+          parent_id: attrs["book_id"],
+          url: url
+        )
+        link.assign_attributes(
+          name: attrs["name"],
+          description: attrs["description"],
+          submitted_by_id: attrs["user_id"],
+          source: source,
+          source_name: (source == :other ? extract_host(url) : nil),
+          link_category: :information,
+          public: true,
+          created_at: attrs["created_at"],
+          updated_at: attrs["updated_at"]
+        )
+        link.save!
+      end
+
+      def normalize_url(url)
+        url.to_s.match?(%r{\Ahttps?://}i) ? url : "https://#{url}"
+      end
+
+      def extract_host(url)
+        url.to_s.sub(%r{\Ahttps?://}i, "").split("/").first.to_s.downcase.sub(/\Awww\./, "")
+      end
+
+      def source_for(url)
+        host = extract_host(url)
+        return :wikipedia if host.end_with?("wikipedia.org")
+        return :goodreads if host == "goodreads.com" || host.end_with?(".goodreads.com")
+        return :amazon if host.include?("amazon.")
+        return :bookshop_org if host == "bookshop.org" || host.end_with?(".bookshop.org")
+        :other
+      end
+    end
+  end
+end
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `cd web-app && bin/rails test test/lib/services/books_migration/external_link_migrator_test.rb`
+Expected: PASS — 8 runs, 0 failures, 0 errors.
+
+- [ ] **Step 6: Add the orchestration rake task**
+
+In `web-app/lib/tasks/data_migration.rake`, add this task after the `category_items` task (before the `all` task):
+
+```ruby
+  desc "Migrate legacy links into external_links (Books::Book parent; source inferred from host)"
+  task external_links: :environment do
+    pp Services::BooksMigration::ExternalLinkMigrator.call
+  end
+```
+
+Then append `:external_links` to the end of the `:all` task list:
+
+```ruby
+  desc "Run all Phase-1 migrators in dependency order"
+  task all: [:languages, :users, :authors, :books, :book_authors, :editions, :identifiers, :categories, :category_items, :external_links]
+```
+
+- [ ] **Step 7: Verify the rake task is registered**
+
+Run: `cd web-app && bin/rails -T data_migration:external_links`
+Expected: lists `rake data_migration:external_links  # Migrate legacy links into external_links ...`.
+
+- [ ] **Step 8: Lint**
+
+Run: `cd web-app && bundle exec standardrb app/models/legacy_books/link.rb app/lib/services/books_migration/external_link_migrator.rb test/lib/services/books_migration/external_link_migrator_test.rb lib/tasks/data_migration.rake`
+Expected: no offenses (autocorrect with `--fix` if needed, then re-run).
+
+- [ ] **Step 9: Commit**
+
+```bash
+cd web-app && git add app/models/legacy_books/link.rb app/lib/services/books_migration/external_link_migrator.rb test/lib/services/books_migration/external_link_migrator_test.rb lib/tasks/data_migration.rake
+git commit -m "Add ExternalLinkMigrator (legacy links -> external_links)"
+```
+
+---
+
+## Final verification (controller-run against the real legacy DB, after Task 1)
+
+Run by the controlling session (not a subagent — this touches the real legacy replica). Reset dev DB to the migrated baseline first if needed.
+
+- [ ] Run `cd web-app && bin/rails data_migration:external_links` → `{success: true, data: {model: "ExternalLink", count: 13404}}`.
+- [ ] `ExternalLink.where(parent_type: "Books::Book").count == 13404` (was 0).
+- [ ] Source distribution: `ExternalLink.where(parent_type: "Books::Book").group(:source).count` → `{"wikipedia" => 13390, "other" => 13, "goodreads" => 1}`.
+- [ ] Every `other`-source Books link has a non-null `source_name`; no Books link has a null/invalid url; `link_category` all `information`; `public` all true; all `submitted_by_id == 1`.
+- [ ] Legacy `created_at` min/max preserved: `2022-11-05 04:12:17 UTC` … `2026-06-20 04:15:26 UTC`.
+- [ ] Pre-existing `amazon` (non-Books) rows untouched: `ExternalLink.where.not(parent_type: "Books::Book").count` unchanged (15,677).
+- [ ] Idempotent: a second `data_migration:external_links` run leaves the Books::Book `external_links` count at 13,404.
+- [ ] Full suite green (`bin/rails test`); `bundle exec standardrb` and `bin/brakeman --no-pager` clean.
+
+---
+
+## Self-Review
+
+**Spec coverage** (against `docs/superpowers/specs/2026-07-08-books-external-links-migration-design.md`):
+- D-write (per-row AR, find_or_initialize_by, fresh id, no unique index) → Task 1 Step 4; idempotency test (Step 2). ✓
+- D-timestamps (preserve created_at/updated_at) → Step 4 assign; preservation test. ✓
+- D-source (host via string ops, host→enum map) → `source_for`/`extract_host` (Step 4); source-per-host + non-ASCII tests. ✓
+- D-source_name (host for `other` only) → Step 4; dedicated test. ✓
+- D-name (verbatim) → Step 4 `name: attrs["name"]`; mapping test asserts "Wikipedia". ✓
+- D-category (`:information`) → Step 4; mapping test asserts `link_category_information?`. ✓
+- D-url (normalize scheme-less) → `normalize_url` (Step 4); normalize test. ✓
+- D-public (true) → Step 4; mapping test. ✓
+- D-fail-loud (validation + FK, base rescue names id) → Step 4 relies on required `belongs_to :parent`; missing-book test asserts `/4242/`. ✓
+- No schema change → File Structure / Global Constraints; no migration task. ✓
+- Orchestration (`:external_links` after `:users`/`:books`, appended to `:all`) → Steps 6-7. ✓
+
+**Placeholder scan:** No TBD/TODO; every code step has complete code; every run step has an exact command + expected output. ✓
+
+**Type consistency:** `ExternalLinkMigrator.call` returns `{success:, data: {model:, count:}}` (inherited from `Migrator#call`, matched in tests). `source_for` returns a Symbol; `assign_attributes(source: symbol)` is valid for the `prefix: true` enum, and `link.source` reads back the String value the tests compare against (`assert_equal "wikipedia", link.source`). `extract_host` returns a String used both for `source_name` and inside `source_for`. `legacy_model`/`model_key`/`upsert_row` are the exact private methods the base `Migrator` calls. ✓

--- a/docs/superpowers/specs/2026-07-08-books-external-links-migration-design.md
+++ b/docs/superpowers/specs/2026-07-08-books-external-links-migration-design.md
@@ -1,0 +1,126 @@
+# External Links Migration (legacy `links` → `external_links`) — Design
+
+**Status:** Approved 2026-07-08.
+**Scope:** One migration increment on top of the merged books data (Phase 1a/1b + editions + identifiers + categories + ISBN + **users**). Migrate the legacy `links` table into the polymorphic **global** `ExternalLink` model, parented to `Books::Book` (preserved ids), with `submitted_by` resolving to the now-migrated users. Fresh ids. No schema change.
+**Parent design:** `docs/superpowers/specs/2026-07-03-old-site-data-migration-design.md`.
+**Depends on:** the merged `users` increment (`submitted_by_id → users.id`) — that FK is why this increment waited.
+
+## Goal
+
+Get all 13,404 legacy `links` rows into `external_links` as `Books::Book`-parented links, faithfully preserving url, name, submitter, and timestamps, with a `source` inferred from the URL host. The load is idempotent and re-runnable.
+
+## Legacy data (local restore, introspected 2026-07-08)
+
+`links`: **13,404 rows**. Columns: `id, name, url, user_id, description, book_id, created_at, updated_at`. Schema declares `url`, `user_id`, `book_id` all `NOT NULL`.
+
+Data-quality facts that drive the design:
+
+| Fact | Value | Handling |
+|---|---|---|
+| Cardinality | **exactly 1 link per book** (13,404 distinct `book_id`) | — |
+| Submitter | **all 13,404 rows are `user_id = 1`** (admin; migrated, present) | `submitted_by_id = 1` |
+| Orphan book FKs | **0** — every `book_id` exists in `Books::Book` | required `belongs_to :parent` fails loud if ever violated |
+| Orphan user FKs | **0** — user 1 present | DB FK on `submitted_by_id` fails loud if ever violated |
+| `name` | present on every row, but **the constant `"Wikipedia"`** — even on the 15 non-Wikipedia links | **migrated verbatim** (D-name) |
+| `description` | **all null/blank** | → nil |
+| `url` scheme | all present; **1 row** (`en.wikipedia.org/wiki/The_Hunting_of_the_Snark`) lacks `http(s)://` and fails the model's URL format validation | **normalized** (D-url) |
+| Hosts | ~99.9% Wikipedia (13,390 across en/de/es/nl/fr, incl. 3 non-ASCII/scheme-less); rest: 7 books.google, 3 time.com, 3 powells, 1 goodreads | host→`source` map (D-source) |
+| Non-ASCII urls | 2 Wikipedia urls contain `ö`/`è` and make `URI.parse` **raise** | host extracted by string ops, not `URI.parse` (D-source) |
+| Duplicates | **0** duplicate `[book_id, url]` | natural key clean |
+| Timestamps | `created_at` spans **517 distinct days (2022→2026)**; `updated_at == created_at` everywhere | **preserved** (D-write) |
+| Target table | `external_links` already holds 15,677 rows (all `amazon`, all non-`Books::Book`) | Books links are a clean insert; no collisions |
+
+## Decisions
+
+- **D-write — per-row AR `Migrator` subclass, not `BulkUpsertMigrator`.** `find_or_initialize_by(parent_type: "Books::Book", parent_id: book_id, url:)`, assign, `save!` (mirrors `EditionMigrator`'s per-row style). Rationale: the natural key `[parent_type, parent_id, url]` has **no unique index** on `external_links`, and `upsert_all` (which `BulkUpsertMigrator` requires) needs one — adding a unique index to a shared, 4-domain, 15,677-row production table is out of scope and higher blast-radius than this increment warrants. Per-row AR gives idempotency via `find_or_initialize_by`, **runs model validations** (fail-loud for free), and 13,404 rows is trivial per-row (books/editions already migrate per-row at larger scale). Fresh ids (links are not id-preserving; only `Books::Book` and `User` preserve ids).
+- **D-timestamps — preserve legacy `created_at`/`updated_at`.** They span 517 days (not a single bulk import), so they carry real signal. With per-row AR, assigning **non-nil** `created_at`/`updated_at` before `save!` means AR's timestamp callback leaves them untouched on create (`_create_record` only fills a timestamp when it reads back falsy). On an idempotent re-run the record is found and unchanged, so `save!` is a no-op and timestamps stay put.
+- **D-source — infer `source` from a robustly-extracted host.** Extract host by string ops (strip scheme, take up to the first `/`, downcase, drop leading `www.`) — **not** `URI.parse`, which raises on the two non-ASCII Wikipedia urls. Map:
+  - host ends with `wikipedia.org` → `wikipedia`
+  - host is/ends with `goodreads.com` → `goodreads`
+  - host contains `amazon.` → `amazon`
+  - host is/ends with `bookshop.org` → `bookshop_org`
+  - else → `other`
+  (`musicbrainz`/`discogs` are music-domain and do not occur.) Verified over the real data with this exact logic: **13,390 `wikipedia`, 1 `goodreads`, 13 `other` (7 books.google, 3 time.com, 3 powells), 0 amazon/bookshop**.
+- **D-source_name — set `source_name` to the host for `other`-source rows only.** `ExternalLink` validates `source_name` presence when `source_other?`; the host (e.g. `"books.google.com"`) is a deterministic, meaningful value. `nil` for all non-`other` rows.
+- **D-name — migrate `name` verbatim** (owner decision, 2026-07-08). Every row keeps its legacy `"Wikipedia"` label, including the 15 mislabeled non-Wikipedia rows. This is a faithful migration of what the old site displayed; the mislabeling is pre-existing legacy data, not introduced here, and correcting it is out of scope. Keeps the migrator trivial.
+- **D-category — `link_category = :information` for all rows** (owner decision, 2026-07-08). Accurate for the overwhelming Wikipedia-reference majority and reasonable for the ~15 others (all book-reference links). Simple constant.
+- **D-url — normalize scheme-less urls** (owner decision, 2026-07-08): if a url does not start with `http(s)://`, prepend `https://`. Fixes the single offending row and acts as a general safety net so a cosmetic legacy defect never aborts the run.
+- **D-public — `public = true`** for all (design-doc default; these are curated reference links).
+- **D-fail-loud — rely on AR validation + DB FK, both wrapped by the base rescue.** `belongs_to :parent` is required (`belongs_to_required_by_default = true`, `parent` not optional — confirmed), so a missing `Books::Book` raises `Validation failed: Parent must exist` on `save!`. `submitted_by_id` has a DB FK to `users`, so a missing user raises on insert. The base `Migrator`'s per-row rescue re-raises naming the **legacy link id** (`"External link migration failed at legacy id=… "`). No custom preload guard is needed — per-row AR surfaces both FK failures loudly and precisely. (Contrast `CategoryItemMigrator`, which needed an explicit guard only because its bulk `upsert_all` path runs no validations.)
+
+## Schema change
+
+**None.** `external_links` already exists with the needed columns and polymorphic `parent`. No new index (D-write).
+
+## Source → target mapping (`links` → `external_links`, fresh id)
+
+| new column | legacy source | handling |
+|---|---|---|
+| `id` | — | fresh (auto) |
+| `parent_type` | (constant) | `"Books::Book"` |
+| `parent_id` | `book_id` | direct (books preserve id); required-`belongs_to` validates existence |
+| `submitted_by_id` | `user_id` | direct (users preserve id); DB FK enforces existence |
+| `url` | `url` | **normalized**: prepend `https://` if scheme-less (D-url) |
+| `name` | `name` | **verbatim** (D-name) — `"Wikipedia"` for every row |
+| `description` | `description` | direct (all nil in practice) |
+| `source` | derived from host | host→enum map (D-source) |
+| `source_name` | derived from host | host string for `other` rows only, else nil (D-source_name) |
+| `link_category` | (constant) | `:information` (D-category) |
+| `public` | (constant) | `true` (D-public) |
+| `created_at` / `updated_at` | same | **preserved** (D-timestamps) |
+
+Left unset (defaults): `click_count` (0), `metadata` (`{}`), `price_cents` (nil).
+
+## Migrator
+
+`Services::BooksMigration::ExternalLinkMigrator` — a **`Migrator`** (per-row AR) subclass:
+
+- `legacy_model = LegacyBooks::Link` (new read-only model, `self.table_name = "links"`).
+- `model_key = "ExternalLink"`.
+- `upsert_row(attrs)`: normalize url → `find_or_initialize_by(parent_type: "Books::Book", parent_id: attrs["book_id"], url: normalized_url)` → assign `name`, `description`, `submitted_by_id`, `source`, `source_name`, `link_category: :information`, `public: true`, and legacy `created_at`/`updated_at` → `save!`.
+- Host extraction + source mapping + source_name as small private helpers (or a thin transformer, matching the `*_transformer.rb` house style where the mapping is non-trivial). Given the host/source logic is the only real logic, a companion `ExternalLinkTransformer` mirroring `EditionTransformer` is optional; a couple of private methods on the migrator are sufficient. **Implementation may choose** whichever reads cleaner; tests target public behavior either way.
+- No `finalize` (no counter caches; `external_links` has none for `Books::Book`).
+
+Idempotent on the natural key `[parent_type, parent_id, url]` via `find_or_initialize_by`.
+
+## Orchestration
+
+Add `data_migration:external_links` task calling `ExternalLinkMigrator.call`. Insert `:external_links` into `data_migration:all` **after `:users`** (needs `submitted_by`) **and after `:books`** (needs the `Books::Book` parents) — e.g. at the end of the current chain, `[:languages, :users, :authors, :books, :book_authors, :editions, :identifiers, :categories, :category_items, :external_links]`.
+
+## Testing (Minitest + Mocha, stub `legacy_each`)
+
+Public-behavior tests, stubbing the legacy stream (`legacy_each`) so no legacy connection opens. Use existing `Books::Book` + `User` fixtures for parents/submitters.
+
+- Maps a fully-populated legacy row → correct `external_links` row: `parent` = the `Books::Book`, `submitted_by` = the user, url/name/timestamps preserved, `public = true`, `link_category = information`.
+- **Source mapping** per host: `en.wikipedia.org`/`de.wikipedia.org` → `wikipedia`; `goodreads.com` → `goodreads`; `books.google.com`/`time.com`/`powells.com` → `other` **with `source_name` = host**; an `amazon.` url → `amazon`; a `bookshop.org` url → `bookshop_org`.
+- **Non-ASCII url** (contains `ö`/`è`) classifies as `wikipedia` without raising (proves host extraction avoids `URI.parse`).
+- **Scheme-less url** is normalized (`https://…`) and the row saves (passes URL format validation).
+- Legacy `created_at`/`updated_at` **preserved** (not overwritten with "now").
+- **Idempotent:** re-running the same row leaves `ExternalLink.count` unchanged and does not duplicate.
+- **Fail-loud:** a row whose `book_id` has no `Books::Book` raises, and the error names the legacy link id (base rescue wraps `belongs_to :parent` validation).
+- `source_name` is nil for non-`other` sources.
+
+## E2e verification (controller-run against the real legacy DB)
+
+Reset dev DB to the migrated baseline, run `data_migration:external_links`, then verify:
+- `ExternalLink.where(parent_type: "Books::Book").count == 13,404` (was 0); total rises by 13,404.
+- `source` distribution matches expectation (13,390 `wikipedia`, 1 `goodreads`, 13 `other`); every `other` row has a non-null `source_name`; **no** `Books::Book` link has a null/invalid url.
+- All `submitted_by_id == 1`; every `parent_id` resolves to a real `Books::Book`.
+- Legacy `created_at` min/max preserved (2022-11-05 … 2026-06-20); `link_category` all `information`; `public` all true.
+- The pre-existing 15,677 `amazon` (non-Books) rows are untouched.
+- **Idempotent:** a second run leaves the Books::Book `external_links` count unchanged.
+- Full suite green; standardrb + brakeman clean.
+
+## Out of scope
+- Any unique index / DB constraint on `external_links` `[parent, url]` (D-write).
+- Correcting the 15 mislabeled `"Wikipedia"` names (D-name).
+- `click_count`/`price_cents`/`metadata` population (no legacy source).
+- Non-book link parents (legacy `links` are 100% book-parented).
+- Music/Movies/Games external links (separate domains/sources).
+
+## References
+- Parent design: `docs/superpowers/specs/2026-07-03-old-site-data-migration-design.md`
+- Prior increment (template): `docs/superpowers/specs/2026-07-07-users-migration-design.md`
+- `Migrator` base (per-row AR): `app/lib/services/books_migration/migrator.rb`; `EditionMigrator` (per-row style): `app/lib/services/books_migration/edition_migrator.rb`
+- `ExternalLink` model: `app/models/external_link.rb`
+- Orchestrator: `lib/tasks/data_migration.rake`

--- a/web-app/app/lib/services/books_migration/external_link_migrator.rb
+++ b/web-app/app/lib/services/books_migration/external_link_migrator.rb
@@ -1,0 +1,65 @@
+module Services
+  module BooksMigration
+    # Legacy `links` -> polymorphic ExternalLink, parented to Books::Book (preserved
+    # ids), submitted_by -> the migrated user. Per-row AR (find_or_initialize_by on the
+    # natural key [parent, url]) because external_links has no unique index to upsert
+    # against. Validations run, so fail-loud is free: a missing Books::Book fails the
+    # required belongs_to :parent, a missing user hits the submitted_by_id DB FK; the
+    # base rescue names the legacy link id. `source` is inferred from the URL host by
+    # string ops (not URI.parse, which raises on the non-ASCII Wikipedia urls). `name`
+    # is migrated verbatim, `link_category` is always :information, and scheme-less urls
+    # are normalized to https://. Legacy created_at/updated_at are preserved (assigning
+    # non-nil timestamps leaves AR's create-time callback untouched). Idempotent on
+    # [parent, url].
+    class ExternalLinkMigrator < Migrator
+      private
+
+      def legacy_model
+        LegacyBooks::Link
+      end
+
+      def model_key
+        "ExternalLink"
+      end
+
+      def upsert_row(attrs)
+        url = normalize_url(attrs["url"])
+        source = source_for(url)
+        link = ExternalLink.find_or_initialize_by(
+          parent_type: "Books::Book",
+          parent_id: attrs["book_id"],
+          url: url
+        )
+        link.assign_attributes(
+          name: attrs["name"],
+          description: attrs["description"],
+          submitted_by_id: attrs["user_id"],
+          source: source,
+          source_name: ((source == :other) ? extract_host(url) : nil),
+          link_category: :information,
+          public: true,
+          created_at: attrs["created_at"],
+          updated_at: attrs["updated_at"]
+        )
+        link.save!
+      end
+
+      def normalize_url(url)
+        url.to_s.match?(%r{\Ahttps?://}i) ? url : "https://#{url}"
+      end
+
+      def extract_host(url)
+        url.to_s.sub(%r{\Ahttps?://}i, "").split("/").first.to_s.downcase.sub(/\Awww\./, "")
+      end
+
+      def source_for(url)
+        host = extract_host(url)
+        return :wikipedia if host.end_with?("wikipedia.org")
+        return :goodreads if host == "goodreads.com" || host.end_with?(".goodreads.com")
+        return :amazon if host.include?("amazon.")
+        return :bookshop_org if host == "bookshop.org" || host.end_with?(".bookshop.org")
+        :other
+      end
+    end
+  end
+end

--- a/web-app/app/models/legacy_books/link.rb
+++ b/web-app/app/models/legacy_books/link.rb
@@ -1,0 +1,5 @@
+module LegacyBooks
+  class Link < Record
+    self.table_name = "links"
+  end
+end

--- a/web-app/lib/tasks/data_migration.rake
+++ b/web-app/lib/tasks/data_migration.rake
@@ -48,6 +48,11 @@ namespace :data_migration do
     pp Services::BooksMigration::CategoryItemMigrator.call
   end
 
+  desc "Migrate legacy links into external_links (Books::Book parent; source inferred from host)"
+  task external_links: :environment do
+    pp Services::BooksMigration::ExternalLinkMigrator.call
+  end
+
   desc "Run all Phase-1 migrators in dependency order"
-  task all: [:languages, :users, :authors, :books, :book_authors, :editions, :identifiers, :categories, :category_items]
+  task all: [:languages, :users, :authors, :books, :book_authors, :editions, :identifiers, :categories, :category_items, :external_links]
 end

--- a/web-app/test/lib/services/books_migration/external_link_migrator_test.rb
+++ b/web-app/test/lib/services/books_migration/external_link_migrator_test.rb
@@ -131,6 +131,14 @@ module Services
         refute result[:success]
         assert_match(/4242/, result[:error])
       end
+
+      test "fails loud naming the legacy id when the submitting user is missing" do
+        missing_user = User.maximum(:id).to_i + 999_999
+        result = run_migrator([legacy_row("id" => 4343, "user_id" => missing_user)])
+
+        refute result[:success]
+        assert_match(/4343/, result[:error])
+      end
     end
   end
 end

--- a/web-app/test/lib/services/books_migration/external_link_migrator_test.rb
+++ b/web-app/test/lib/services/books_migration/external_link_migrator_test.rb
@@ -1,0 +1,136 @@
+require "test_helper"
+
+module Services
+  module BooksMigration
+    class ExternalLinkMigratorTest < ActiveSupport::TestCase
+      setup do
+        @book = Books::Book.create!(title: "Link Parent")
+        @user = users(:regular_user)
+      end
+
+      def run_migrator(rows)
+        migrator = ExternalLinkMigrator.new
+        migrator.stubs(:legacy_each).multiple_yields(*rows.zip)
+        migrator.call
+      end
+
+      def legacy_row(overrides = {})
+        {
+          "id" => 1,
+          "name" => "Wikipedia",
+          "url" => "http://en.wikipedia.org/wiki/Test",
+          "user_id" => @user.id,
+          "description" => nil,
+          "book_id" => @book.id,
+          "created_at" => Time.utc(2022, 11, 5, 4, 12, 17),
+          "updated_at" => Time.utc(2022, 11, 5, 4, 12, 17)
+        }.merge(overrides)
+      end
+
+      test "maps a legacy link to a Books::Book-parented ExternalLink" do
+        result = run_migrator([legacy_row])
+
+        assert result[:success], result[:error]
+        assert_equal 1, result[:data][:count]
+        assert_equal "ExternalLink", result[:data][:model]
+
+        link = ExternalLink.find_by(parent_type: "Books::Book", parent_id: @book.id)
+        assert_not_nil link
+        assert_equal @book, link.parent
+        assert_equal @user, link.submitted_by
+        assert_equal "Wikipedia", link.name
+        assert_nil link.description
+        assert_equal "http://en.wikipedia.org/wiki/Test", link.url
+        assert link.public?
+        assert link.link_category_information?
+        assert link.source_wikipedia?
+        assert_nil link.source_name
+      end
+
+      test "preserves legacy created_at/updated_at" do
+        ts = Time.utc(2024, 12, 15, 9, 0, 0)
+        run_migrator([legacy_row("created_at" => ts, "updated_at" => ts)])
+
+        link = ExternalLink.find_by(parent_type: "Books::Book", parent_id: @book.id)
+        assert_equal ts, link.created_at
+        assert_equal ts, link.updated_at
+      end
+
+      test "infers source from the URL host" do
+        cases = {
+          "http://en.wikipedia.org/wiki/A" => "wikipedia",
+          "http://de.wikipedia.org/wiki/B" => "wikipedia",
+          "https://www.goodreads.com/book/show/1" => "goodreads",
+          "http://www.amazon.com/dp/123" => "amazon",
+          "https://bookshop.org/books/x" => "bookshop_org",
+          "http://books.google.com/books?q=x" => "other",
+          "http://www.time.com/x" => "other",
+          "http://www.powells.com/biblio/x" => "other"
+        }
+        rows = cases.keys.each_with_index.map do |url, i|
+          book = Books::Book.create!(title: "Src Parent #{i}")
+          legacy_row("id" => 100 + i, "book_id" => book.id, "url" => url)
+        end
+        result = run_migrator(rows)
+
+        assert result[:success], result[:error]
+        cases.each do |url, expected|
+          link = ExternalLink.find_by(url: url)
+          assert_not_nil link, "no link for #{url}"
+          assert_equal expected, link.source, "wrong source for #{url}"
+        end
+      end
+
+      test "sets source_name to the host for other-source links only" do
+        other_book = Books::Book.create!(title: "Other Parent")
+        run_migrator([
+          legacy_row("id" => 200, "book_id" => other_book.id, "url" => "http://books.google.com/books?q=x"),
+          legacy_row("id" => 201, "url" => "http://en.wikipedia.org/wiki/Y")
+        ])
+
+        other = ExternalLink.find_by(url: "http://books.google.com/books?q=x")
+        assert other.source_other?
+        assert_equal "books.google.com", other.source_name
+
+        wiki = ExternalLink.find_by(url: "http://en.wikipedia.org/wiki/Y")
+        assert wiki.source_wikipedia?
+        assert_nil wiki.source_name
+      end
+
+      test "classifies non-ASCII wikipedia URLs without raising" do
+        url = "http://en.wikipedia.org/wiki/Gödel,_Escher,_Bach"
+        result = run_migrator([legacy_row("url" => url)])
+
+        assert result[:success], result[:error]
+        assert ExternalLink.find_by(url: url).source_wikipedia?
+      end
+
+      test "normalizes scheme-less URLs to https" do
+        result = run_migrator([legacy_row("url" => "en.wikipedia.org/wiki/The_Hunting_of_the_Snark")])
+
+        assert result[:success], result[:error]
+        link = ExternalLink.find_by(parent_type: "Books::Book", parent_id: @book.id)
+        assert_equal "https://en.wikipedia.org/wiki/The_Hunting_of_the_Snark", link.url
+        assert link.source_wikipedia?
+      end
+
+      test "is idempotent on [parent, url]: re-running does not duplicate" do
+        run_migrator([legacy_row])
+
+        assert_no_difference -> { ExternalLink.count } do
+          result = run_migrator([legacy_row])
+          assert result[:success], result[:error]
+          assert_equal 1, result[:data][:count]
+        end
+      end
+
+      test "fails loud naming the legacy id when the book is missing" do
+        missing = Books::Book.maximum(:id).to_i + 999_999
+        result = run_migrator([legacy_row("id" => 4242, "book_id" => missing)])
+
+        refute result[:success]
+        assert_match(/4242/, result[:error])
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

8th increment of the legacy TheGreatestBooks → new app data migration. Migrates the legacy `links` table (13,404 rows) into the polymorphic global `ExternalLink` model, parented to `Books::Book` (ids preserved by an earlier increment), with `submitted_by` now resolving to the migrated users (PR #161).

This increment was unblocked by the users migration — every legacy link's `submitted_by_id` FK now resolves.

## What the real legacy data looks like (introspected 2026-07-08)

- **Exactly one link per book** (13,404 distinct `book_id`), **all submitted by a single admin user** (`user_id = 1`), zero orphan book/user FKs, zero duplicate `[book_id, url]`.
- `name` is always present but the **constant `"Wikipedia"`** on every row (including the 15 non-Wikipedia links); `description` is always blank.
- ~99.9% Wikipedia. Verified source distribution with the exact mapping logic: **`wikipedia` 13,390 / `other` 13 / `goodreads` 1**.
- Two Wikipedia URLs contain non-ASCII characters (make `URI.parse` **raise**); one URL is missing its scheme.
- `created_at` spans 517 distinct days (2022→2026); `updated_at == created_at` everywhere.

## Design

- **Per-row AR `Migrator`** (`ExternalLinkMigrator`), not `BulkUpsertMigrator` — the natural key `[parent, url]` has no unique index on `external_links`, and adding one to the shared 4-domain table is out of scope. Idempotent via `find_or_initialize_by(parent_type:, parent_id:, url:)` on the **normalized** url.
- **Fail loud for free:** a missing `Books::Book` fails the required `belongs_to :parent` validation; a missing user hits the DB FK on `submitted_by_id`. Both are wrapped by the base `Migrator` rescue that names the legacy link id.
- **`source` inferred from a string-extracted host** (never `URI.parse`) → `wikipedia` / `goodreads` / `amazon` / `bookshop_org` / `other`; `source_name` = host for `other` rows only.
- Owner decisions: `name` migrated **verbatim**; `link_category` = `information` for all; scheme-less URLs **normalized** to `https://`; `public` = true; legacy `created_at`/`updated_at` **preserved**.
- **No schema change.**

## Files

- `app/lib/services/books_migration/external_link_migrator.rb` — the migrator
- `app/models/legacy_books/link.rb` — read-only legacy model
- `lib/tasks/data_migration.rake` — `data_migration:external_links` task + appended to `:all`
- `test/lib/services/books_migration/external_link_migrator_test.rb` — 9 tests
- `docs/superpowers/{specs,plans}/2026-07-08-books-external-links-migration*` — design + plan

## Verification

- **Unit:** 9 migrator tests (incl. non-ASCII URL, scheme-less URL, idempotency, and fail-loud for both a missing book and a missing user); full suite **4442 runs, 0 failures/errors/skips**; standardrb clean; brakeman at baseline (0 new).
- **E2E (real legacy DB, dev, run twice):** `{success: true, count: 13404}`. Books::Book links 0 → 13,404; source distribution exactly `{wikipedia: 13390, other: 13, goodreads: 1}`; all `information` / `public` / `submitted_by 1`; every `other` row has a `source_name`; zero null/invalid URLs; `created_at` preserved (`2022-11-05…2026-06-20`); the pre-existing 15,677 `amazon` (non-Books) rows untouched. Second run byte-identical (idempotent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
