### PR TITLE
Migrate legacy lists + list_items (Phase 2a)

### DIFF
--- a/docs/superpowers/plans/2026-07-09-books-lists-migration.md
+++ b/docs/superpowers/plans/2026-07-09-books-lists-migration.md
@@ -1,0 +1,550 @@
+# Lists Migration Implementation Plan (Phase 2a)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Migrate legacy `lists` (1,030 rows) into STI `Books::List` preserving ids, and legacy `list_items` (65,252 rows) into the polymorphic `list_items` with `listable = Books::Book`.
+
+**Architecture:** Two `BulkUpsertMigrator` subclasses. `ListMigrator` upserts keyed on `:id` (bypassing `List` callbacks/validations so the legacy `formatted_text` survives as `simplified_content` and the `status` enum is symbol-remapped). `ListItemMigrator` upserts on the natural-key unique index `[list_id, listable_type, listable_id]`, guarding the polymorphic `listable` with a preloaded `Books::Book` id set (fail-loud). No schema change.
+
+**Tech Stack:** Rails 8, Minitest + Mocha, PostgreSQL. Reuses `Services::BooksMigration::BulkUpsertMigrator` (batched `upsert_all` + `record_timestamps?` hook) and `LegacyBooks::Record` (read-only legacy replica).
+
+## Global Constraints
+
+- Run **all** Rails commands from `web-app/` (`cd web-app` first). Docs live at repo root under `docs/`.
+- Lint with `bundle exec standardrb` (NOT rubocop); must be clean.
+- Namespace `Services::BooksMigration::` (migrators) and `LegacyBooks::` (legacy models); tests mirror the namespace (`module Services; module BooksMigration; class …Test`).
+- **No schema change.** `lists` and `list_items` already have every needed column.
+- **Both migrators are `BulkUpsertMigrator` subclasses**, `record_timestamps?` = false (preserve legacy `created_at`/`updated_at`).
+- **`status` symbol-remap** (the landmine): old `{unapproved:0, approved:1, active:2, rejected:3, inactive:4, pending:5}` → new `{unapproved:0, approved:1, rejected:2, active:3}`, via `{0=>0, 1=>1, 2=>3, 3=>2, 4=>0, 5=>0}`. **Raise** on any unmapped status (fail-loud).
+- `raw_content ← raw_html`; `simplified_content ← formatted_text`; `items_json` **nil** (skip `books_json`).
+- `list_items`: `listable = Books::Book` / `listable_id = book_id`; `metadata ← parse(pending_book_data)`; `verified = false`; **fail-loud** on a `book_id` with no migrated `Books::Book`.
+- Each migrator carries ONE class-level doc comment (house style — every sibling migrator has one); no other code comments.
+
+## File Structure
+
+- **Create** `web-app/app/models/legacy_books/list.rb` — read-only legacy `lists` model.
+- **Create** `web-app/app/lib/services/books_migration/list_migrator.rb` — the lists migrator (Task 1).
+- **Create** `web-app/test/lib/services/books_migration/list_migrator_test.rb` (Task 1).
+- **Create** `web-app/app/models/legacy_books/list_item.rb` — read-only legacy `list_items` model.
+- **Create** `web-app/app/lib/services/books_migration/list_item_migrator.rb` — the list_items migrator (Task 2).
+- **Create** `web-app/test/lib/services/books_migration/list_item_migrator_test.rb` (Task 2).
+- **Modify** `web-app/lib/tasks/data_migration.rake` — `:lists` + `:list_items` tasks + `:all` insertion (Task 3).
+
+---
+
+## Task 1: `LegacyBooks::List` + `ListMigrator`
+
+**Files:**
+- Create: `web-app/app/models/legacy_books/list.rb`
+- Create: `web-app/app/lib/services/books_migration/list_migrator.rb`
+- Test: `web-app/test/lib/services/books_migration/list_migrator_test.rb`
+
+**Interfaces:**
+- Consumes: `BulkUpsertMigrator` base (`call` → `{success:, data:{model:, count:}}`; hooks `legacy_model`/`model_key`/`target_model`/`unique_by`/`build_rows`/`record_timestamps?`); `List`/`Books::List` (target; `enum :status, {unapproved:0, approved:1, rejected:2, active:3}`).
+- Produces: `Services::BooksMigration::ListMigrator.call`; `LegacyBooks::List` (`table_name = "lists"`).
+
+- [ ] **Step 1: Create the read-only legacy model**
+
+Create `web-app/app/models/legacy_books/list.rb`:
+
+```ruby
+module LegacyBooks
+  class List < Record
+    self.table_name = "lists"
+  end
+end
+```
+
+- [ ] **Step 2: Write the failing test file**
+
+Create `web-app/test/lib/services/books_migration/list_migrator_test.rb`:
+
+```ruby
+require "test_helper"
+
+module Services
+  module BooksMigration
+    class ListMigratorTest < ActiveSupport::TestCase
+      setup do
+        @user = users(:regular_user)
+      end
+
+      def run_migrator(rows)
+        migrator = ListMigrator.new
+        migrator.stubs(:legacy_each).multiple_yields(*rows.zip)
+        migrator.call
+      end
+
+      def legacy_row(overrides = {})
+        {
+          "id" => 990001,
+          "name" => "Best Books",
+          "description" => "desc",
+          "source" => "example.com",
+          "url" => "https://example.com/list",
+          "status" => 2,
+          "year_published" => 2020,
+          "number_of_voters" => 100,
+          "estimated_quality" => 5,
+          "submitted_by_id" => @user.id,
+          "high_quality_source" => true,
+          "category_specific" => false,
+          "location_specific" => nil,
+          "yearly_award" => false,
+          "voter_count_unknown" => nil,
+          "voter_names_unknown" => nil,
+          "raw_html" => "<ol><li>A</li></ol>",
+          "formatted_text" => "A",
+          "created_at" => Time.utc(2015, 1, 2, 3, 4, 5),
+          "updated_at" => Time.utc(2016, 2, 3, 4, 5, 6)
+        }.merge(overrides)
+      end
+
+      test "maps a legacy list to Books::List, preserving id" do
+        result = run_migrator([legacy_row])
+
+        assert result[:success], result[:error]
+        assert_equal 1, result[:data][:count]
+        assert_equal "Books::List", result[:data][:model]
+
+        list = List.find(990001)
+        assert_instance_of Books::List, list
+        assert_equal "Best Books", list.name
+        assert_equal "desc", list.description
+        assert_equal "example.com", list.source
+        assert_equal "https://example.com/list", list.url
+        assert list.active?
+        assert_equal 2020, list.year_published
+        assert_equal 100, list.number_of_voters
+        assert_equal 5, list.estimated_quality
+        assert_equal @user, list.submitted_by
+        assert_equal true, list.high_quality_source
+        assert_equal false, list.category_specific
+        assert_nil list.location_specific
+        assert_equal "<ol><li>A</li></ol>", list.raw_content
+        assert_equal "A", list.simplified_content
+        assert_nil list.items_json
+        assert_equal Time.utc(2015, 1, 2, 3, 4, 5), list.created_at
+        assert_equal Time.utc(2016, 2, 3, 4, 5, 6), list.updated_at
+      end
+
+      test "remaps status by symbol" do
+        expected = {0 => "unapproved", 1 => "approved", 2 => "active", 3 => "rejected", 4 => "unapproved", 5 => "unapproved"}
+        expected.each_with_index do |(old, want), i|
+          run_migrator([legacy_row("id" => 991000 + i, "status" => old)])
+          assert_equal want, List.find(991000 + i).status, "old status #{old}"
+        end
+      end
+
+      test "does not run auto_simplify_content (preserves legacy formatted_text)" do
+        run_migrator([legacy_row("id" => 992001, "raw_html" => "<div><script>x</script>Hello</div>", "formatted_text" => "LEGACY")])
+
+        assert_equal "LEGACY", List.find(992001).simplified_content
+      end
+
+      test "fails loud on an unmapped status" do
+        result = run_migrator([legacy_row("id" => 993001, "status" => 9)])
+
+        refute result[:success]
+        assert_match(/993001/, result[:error])
+      end
+
+      test "is idempotent on id" do
+        run_migrator([legacy_row("id" => 994001)])
+
+        assert_no_difference -> { List.count } do
+          run_migrator([legacy_row("id" => 994001, "name" => "Renamed")])
+        end
+        assert_equal "Renamed", List.find(994001).name
+      end
+    end
+  end
+end
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `cd web-app && bin/rails test test/lib/services/books_migration/list_migrator_test.rb`
+Expected: FAIL — `NameError: uninitialized constant Services::BooksMigration::ListMigrator`.
+
+- [ ] **Step 4: Implement the migrator**
+
+Create `web-app/app/lib/services/books_migration/list_migrator.rb`:
+
+```ruby
+module Services
+  module BooksMigration
+    # Legacy `lists` -> STI Books::List, preserving id. Bulk upsert_all bypasses the List
+    # callbacks — crucially before_save :auto_simplify_content, which would re-run the HTML
+    # simplifier over raw_content and overwrite the legacy formatted_text we preserve as
+    # simplified_content — and the validations. status is symbol-remapped (old/new enums
+    # differ: active/rejected swap ints, inactive/pending collapse to unapproved).
+    # raw_content <- raw_html, simplified_content <- formatted_text, items_json skipped
+    # (nil; real items live in list_items). Legacy created_at/updated_at preserved.
+    # Idempotent on id.
+    class ListMigrator < BulkUpsertMigrator
+      # old {unapproved:0, approved:1, active:2, rejected:3, inactive:4, pending:5}
+      # new {unapproved:0, approved:1, rejected:2, active:3}
+      STATUS_MAP = {0 => 0, 1 => 1, 2 => 3, 3 => 2, 4 => 0, 5 => 0}.freeze
+
+      private
+
+      def legacy_model
+        LegacyBooks::List
+      end
+
+      def model_key
+        "Books::List"
+      end
+
+      def target_model
+        List
+      end
+
+      def unique_by
+        :id
+      end
+
+      def record_timestamps?
+        false
+      end
+
+      def build_rows(attrs)
+        [{
+          id: attrs["id"],
+          type: "Books::List",
+          name: attrs["name"],
+          description: attrs["description"],
+          source: attrs["source"],
+          url: attrs["url"],
+          status: remap_status(attrs["status"]),
+          year_published: attrs["year_published"],
+          number_of_voters: attrs["number_of_voters"],
+          estimated_quality: attrs["estimated_quality"],
+          submitted_by_id: attrs["submitted_by_id"],
+          high_quality_source: attrs["high_quality_source"],
+          category_specific: attrs["category_specific"],
+          location_specific: attrs["location_specific"],
+          yearly_award: attrs["yearly_award"],
+          voter_count_unknown: attrs["voter_count_unknown"],
+          voter_names_unknown: attrs["voter_names_unknown"],
+          raw_content: attrs["raw_html"],
+          simplified_content: attrs["formatted_text"],
+          created_at: attrs["created_at"],
+          updated_at: attrs["updated_at"]
+        }]
+      end
+
+      def remap_status(old)
+        STATUS_MAP.fetch(old) { raise "unmapped legacy lists.status=#{old.inspect}" }
+      end
+    end
+  end
+end
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `cd web-app && bin/rails test test/lib/services/books_migration/list_migrator_test.rb`
+Expected: PASS — 5 runs, 0 failures, 0 errors.
+
+- [ ] **Step 6: Lint**
+
+Run: `cd web-app && bundle exec standardrb app/models/legacy_books/list.rb app/lib/services/books_migration/list_migrator.rb test/lib/services/books_migration/list_migrator_test.rb`
+Expected: no offenses (autocorrect with `--fix` if needed, then re-run).
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd web-app && git add app/models/legacy_books/list.rb app/lib/services/books_migration/list_migrator.rb test/lib/services/books_migration/list_migrator_test.rb
+git commit -m "Add ListMigrator (legacy lists -> Books::List)"
+```
+
+---
+
+## Task 2: `LegacyBooks::ListItem` + `ListItemMigrator`
+
+**Files:**
+- Create: `web-app/app/models/legacy_books/list_item.rb`
+- Create: `web-app/app/lib/services/books_migration/list_item_migrator.rb`
+- Test: `web-app/test/lib/services/books_migration/list_item_migrator_test.rb`
+
+**Interfaces:**
+- Consumes: `BulkUpsertMigrator` base (+ `preload_context` hook); `ListItem` (target; unique index `index_list_items_on_list_and_listable_unique` on `[list_id, listable_type, listable_id]`); `Books::Book`, `Books::List`.
+- Produces: `Services::BooksMigration::ListItemMigrator.call`; `LegacyBooks::ListItem` (`table_name = "list_items"`).
+
+- [ ] **Step 1: Create the read-only legacy model**
+
+Create `web-app/app/models/legacy_books/list_item.rb`:
+
+```ruby
+module LegacyBooks
+  class ListItem < Record
+    self.table_name = "list_items"
+  end
+end
+```
+
+- [ ] **Step 2: Write the failing test file**
+
+Create `web-app/test/lib/services/books_migration/list_item_migrator_test.rb`:
+
+```ruby
+require "test_helper"
+
+module Services
+  module BooksMigration
+    class ListItemMigratorTest < ActiveSupport::TestCase
+      setup do
+        @list = Books::List.create!(name: "Item Parent List")
+        @book = Books::Book.create!(title: "Item Book")
+      end
+
+      def run_migrator(rows)
+        migrator = ListItemMigrator.new
+        migrator.stubs(:legacy_each).multiple_yields(*rows.zip)
+        migrator.call
+      end
+
+      def legacy_row(overrides = {})
+        {
+          "id" => 8000001,
+          "list_id" => @list.id,
+          "book_id" => @book.id,
+          "position" => 3,
+          "pending_book_data" => nil,
+          "created_at" => Time.utc(2018, 5, 6, 7, 8, 9),
+          "updated_at" => Time.utc(2019, 6, 7, 8, 9, 10)
+        }.merge(overrides)
+      end
+
+      test "maps a legacy list_item to a Books::Book listable" do
+        result = run_migrator([legacy_row])
+
+        assert result[:success], result[:error]
+        assert_equal 1, result[:data][:count]
+        assert_equal "ListItem", result[:data][:model]
+
+        item = ListItem.find_by(list_id: @list.id, listable_type: "Books::Book", listable_id: @book.id)
+        assert_not_nil item
+        assert_equal @book, item.listable
+        assert_equal 3, item.position
+        assert_equal false, item.verified
+        assert_nil item.metadata
+        assert_equal Time.utc(2018, 5, 6, 7, 8, 9), item.created_at
+        assert_equal Time.utc(2019, 6, 7, 8, 9, 10), item.updated_at
+      end
+
+      test "parses pending_book_data into metadata" do
+        run_migrator([legacy_row("pending_book_data" => '{"title":"T","authors":"A"}')])
+
+        item = ListItem.find_by(list_id: @list.id, listable_id: @book.id)
+        assert_equal({"title" => "T", "authors" => "A"}, item.metadata)
+      end
+
+      test "null position and blank pending_book_data become nil" do
+        run_migrator([legacy_row("position" => nil, "pending_book_data" => "")])
+
+        item = ListItem.find_by(list_id: @list.id, listable_id: @book.id)
+        assert_nil item.position
+        assert_nil item.metadata
+      end
+
+      test "fails loud when the book is not migrated" do
+        missing = Books::Book.maximum(:id).to_i + 999_999
+        result = run_migrator([legacy_row("id" => 8000042, "book_id" => missing)])
+
+        refute result[:success]
+        assert_match(/8000042/, result[:error])
+      end
+
+      test "is idempotent on [list, listable]" do
+        run_migrator([legacy_row])
+
+        assert_no_difference -> { ListItem.count } do
+          run_migrator([legacy_row("position" => 99)])
+        end
+        assert_equal 99, ListItem.find_by(list_id: @list.id, listable_id: @book.id).position
+      end
+    end
+  end
+end
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `cd web-app && bin/rails test test/lib/services/books_migration/list_item_migrator_test.rb`
+Expected: FAIL — `NameError: uninitialized constant Services::BooksMigration::ListItemMigrator`.
+
+- [ ] **Step 4: Implement the migrator**
+
+Create `web-app/app/lib/services/books_migration/list_item_migrator.rb`:
+
+```ruby
+module Services
+  module BooksMigration
+    # Legacy `list_items` -> polymorphic list_items (listable = Books::Book), fresh id.
+    # Bulk upsert on the natural-key unique index [list_id, listable_type, listable_id].
+    # Every legacy row has a non-null book_id (no pending items), so there are no
+    # NULL-in-unique-index rows and (since [list_id, book_id] is unique in the source) no
+    # intra-batch ON CONFLICT double-touch. listable has no DB FK (polymorphic), so a
+    # book_id with no migrated Books::Book is a fail-loud raise naming the legacy
+    # list_item id (preloaded id set). metadata <- parsed pending_book_data (plain jsonb;
+    # a raw string would store as a jsonb string scalar). verified defaults false. Legacy
+    # created_at/updated_at preserved.
+    class ListItemMigrator < BulkUpsertMigrator
+      private
+
+      def legacy_model
+        LegacyBooks::ListItem
+      end
+
+      def model_key
+        "ListItem"
+      end
+
+      def target_model
+        ListItem
+      end
+
+      def unique_by
+        :index_list_items_on_list_and_listable_unique
+      end
+
+      def record_timestamps?
+        false
+      end
+
+      def preload_context
+        @book_ids = Books::Book.pluck(:id).to_set
+      end
+
+      def build_rows(attrs)
+        book_id = attrs["book_id"]
+        unless @book_ids.include?(book_id)
+          raise "no migrated Books::Book for legacy list_items.book_id=#{book_id.inspect} (list_item id=#{attrs["id"]})"
+        end
+
+        [{
+          list_id: attrs["list_id"],
+          listable_type: "Books::Book",
+          listable_id: book_id,
+          position: attrs["position"],
+          metadata: parse_metadata(attrs["pending_book_data"]),
+          verified: false,
+          created_at: attrs["created_at"],
+          updated_at: attrs["updated_at"]
+        }]
+      end
+
+      def parse_metadata(value)
+        return nil if value.blank?
+        JSON.parse(value)
+      end
+    end
+  end
+end
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `cd web-app && bin/rails test test/lib/services/books_migration/list_item_migrator_test.rb`
+Expected: PASS — 5 runs, 0 failures, 0 errors.
+
+- [ ] **Step 6: Lint**
+
+Run: `cd web-app && bundle exec standardrb app/models/legacy_books/list_item.rb app/lib/services/books_migration/list_item_migrator.rb test/lib/services/books_migration/list_item_migrator_test.rb`
+Expected: no offenses (autocorrect with `--fix` if needed, then re-run).
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd web-app && git add app/models/legacy_books/list_item.rb app/lib/services/books_migration/list_item_migrator.rb test/lib/services/books_migration/list_item_migrator_test.rb
+git commit -m "Add ListItemMigrator (legacy list_items -> list_items)"
+```
+
+---
+
+## Task 3: Orchestration
+
+**Files:**
+- Modify: `web-app/lib/tasks/data_migration.rake`
+
+**Interfaces:**
+- Consumes: `ListMigrator` (Task 1), `ListItemMigrator` (Task 2).
+- Produces: rake tasks `data_migration:lists`, `data_migration:list_items`; both appended to `data_migration:all`.
+
+- [ ] **Step 1: Add the rake tasks**
+
+In `web-app/lib/tasks/data_migration.rake`, add these two tasks after the `external_links` task (before the `all` task):
+
+```ruby
+  desc "Migrate legacy lists into Books::List (preserve id; status symbol-remap)"
+  task lists: :environment do
+    pp Services::BooksMigration::ListMigrator.call
+  end
+
+  desc "Migrate legacy list_items into list_items (listable = Books::Book; fresh id)"
+  task list_items: :environment do
+    pp Services::BooksMigration::ListItemMigrator.call
+  end
+```
+
+- [ ] **Step 2: Append to the `:all` task**
+
+Update the `:all` task list to end with `:lists, :list_items` (lists before list_items):
+
+```ruby
+  desc "Run all Phase-1 migrators in dependency order"
+  task all: [:languages, :users, :authors, :books, :book_authors, :editions, :identifiers, :categories, :category_items, :external_links, :lists, :list_items]
+```
+
+- [ ] **Step 3: Verify the tasks are registered**
+
+Run: `cd web-app && bin/rails -T data_migration`
+Expected: the output lists `data_migration:lists` and `data_migration:list_items` with their descriptions.
+
+- [ ] **Step 4: Lint**
+
+Run: `cd web-app && bundle exec standardrb lib/tasks/data_migration.rake`
+Expected: no offenses.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd web-app && git add lib/tasks/data_migration.rake
+git commit -m "Wire lists + list_items into the data_migration rake orchestrator"
+```
+
+---
+
+## Final verification (controller-run against the real legacy DB, after all tasks)
+
+Run by the controlling session (not a subagent). Reset dev DB to the migrated baseline first if needed.
+
+- [ ] Run `cd web-app && bin/rails data_migration:lists` → `{success: true, data: {model: "Books::List", count: 1030}}`, then `data_migration:list_items` → `{success: true, data: {model: "ListItem", count: 65252}}`.
+- [ ] `List.where(type: "Books::List").count == 1030`; ids 1–1,175 present; no collision with the reserved ≥10,001 app lists.
+- [ ] `List.where(type: "Books::List").group(:status).count` → `{"unapproved" => 252, "approved" => 14, "rejected" => 5, "active" => 759}`.
+- [ ] `simplified_content` present on 627 Books::Lists; `raw_content` present on 157; `items_json` null on all 1,030; legacy timestamps preserved.
+- [ ] `ListItem.where(listable_type: "Books::Book").count == 65252`; 0 rows with a null/dangling `listable_id`; `metadata` present on 948; distinct `list_id` = 761.
+- [ ] Idempotent: a second run of each task leaves both counts unchanged.
+- [ ] Full suite green (`bin/rails test`); `bundle exec standardrb` and `bin/brakeman --no-pager` clean (0 new).
+
+---
+
+## Self-Review
+
+**Spec coverage** (against `docs/superpowers/specs/2026-07-09-books-lists-migration-design.md`):
+- D-write-lists (bulk, keyed on :id, bypass callbacks, preserve timestamps) → Task 1 Step 4 (`BulkUpsertMigrator`, `unique_by :id`, `record_timestamps? false`); idempotency + auto_simplify-bypass tests. ✓
+- D-status (symbol-remap, raise on unmapped) → `STATUS_MAP` + `remap_status` (Task 1 Step 4); remap + fail-loud tests. ✓
+- D-simplified (formatted_text) → `simplified_content ← formatted_text` (Step 4); auto_simplify-bypass test asserts "LEGACY". ✓
+- D-items-json (nil) → items_json omitted from build_rows; mapping test asserts `assert_nil list.items_json`. ✓
+- D-write-list-items (bulk on natural-key index) → Task 2 Step 4 (`unique_by :index_list_items_on_list_and_listable_unique`); idempotency test. ✓
+- D-li-failloud (preload Books::Book ids, raise) → `preload_context` + guard (Task 2 Step 4); missing-book test asserts `/8000042/`. ✓
+- D-metadata (parse pending_book_data) → `parse_metadata` (Step 4); metadata + blank tests. ✓
+- D-no-finalize / no schema change → no `finalize`, no migration file. ✓
+- Orchestration (`:lists` before `:list_items`, appended to `:all`) → Task 3. ✓
+
+**Placeholder scan:** No TBD/TODO; every code step has complete code; every run step has an exact command + expected output. ✓
+
+**Type consistency:** Both migrators return `{success:, data:{model:, count:}}` (inherited from `BulkUpsertMigrator#call`; tests assert `model` = `"Books::List"` / `"ListItem"`). `build_rows` returns an array of one row hash (matches `BulkUpsertMigrator#call` doing `build_rows(attrs).each`). `STATUS_MAP.fetch(old) { raise … }` — the raise is caught by the base per-row rescue, which re-raises naming `attrs["id"]`, then the outer rescue returns `{success: false}` (matches the fail-loud tests). `preload_context`/`unique_by`/`record_timestamps?`/`build_rows`/`legacy_model`/`model_key`/`target_model` are the exact hooks `BulkUpsertMigrator` calls. ✓

--- a/docs/superpowers/specs/2026-07-09-books-lists-migration-design.md
+++ b/docs/superpowers/specs/2026-07-09-books-lists-migration-design.md
@@ -30,7 +30,7 @@ Facts that drive the design:
 | `list_items` `book_id` missing from `Books::Book` | **0** of 24,362 distinct | fail-loud guard (D-li-failloud) |
 | duplicate `[list_id, book_id]` | **0** | natural key clean → safe upsert, no intra-batch conflict |
 | `list_items.position` | 38,183 null (58%), **0 ≤ 0** | null→null (model allows blank; non-null all > 0) |
-| `pending_book_data` (text, JSON) | 948 non-blank (e.g. `{"title":…,"authors":…}`) | `metadata ← parse(pending_book_data)` |
+| `pending_book_data` (text) | 948 non-blank, **mixed serialization**: 546 JSON objects `{"title":…,"authors":…}` + 402 YAML `--- !ruby/hash:ActiveSupport::HashWithIndifferentAccess\ntitle:…` (legacy Rails `serialize` drift) | `metadata ← parse(pending_book_data)` — parse **both** formats (D-metadata) |
 | `list_items.verified` | no legacy column | default `false` |
 | timestamps | `lists` and `list_items` `created_at` span years | **preserved** |
 
@@ -42,7 +42,7 @@ Facts that drive the design:
 - **D-items-json — skip `books_json`** (owner decision, 2026-07-09): `items_json` is left **nil** for all lists. `books_json` is ~55% null / ~17% empty-string / only 7.5% real arrays, and the authoritative, structured item data is migrated into `list_items`. Avoids storing junk that would fail `items_json_format` on any later AR edit.
 - **D-write-list-items — `BulkUpsertMigrator`** on the unique index `[list_id, listable_type, listable_id]` (like `CategoryItemMigrator`). All 65,252 rows have a non-null `book_id`, so there are **no NULL-in-unique-index** rows (Postgres treats NULLs as distinct, which would break upsert idempotency) and **no pending items**. The **0 duplicate `[list_id, book_id]`** finding guarantees no intra-batch `ON CONFLICT` double-touch. Legacy timestamps preserved.
 - **D-li-failloud — guard the polymorphic `listable`.** `list_items.listable` has no DB FK (polymorphic), so a `book_id` with no migrated `Books::Book` would silently create a dangling item. `preload_context` loads the `Books::Book` id set; `build_rows` **raises** naming the legacy `list_item` id + `book_id` if the book is missing (mirrors `CategoryItemMigrator`). `list_id` has a real DB FK to `lists` (all present; lists migrate first).
-- **D-metadata — parse `pending_book_data` to a Hash** before upsert (plain jsonb column; a raw string would store as a jsonb string scalar). Blank → nil; malformed JSON raises (base rescue names the legacy id). Mirrors `UserMigrator#parse_provider_data`.
+- **D-metadata — parse `pending_book_data` (JSON *or* YAML) to a plain Hash** before upsert (plain jsonb column; a raw string would store as a jsonb string scalar). The legacy column mixes two serializations (Rails `serialize` drift): JSON objects (`{…}`) and YAML tagged `!ruby/hash:ActiveSupport::HashWithIndifferentAccess`. Detect by leading `---` → `YAML.safe_load(str, permitted_classes: [Symbol, ActiveSupport::HashWithIndifferentAccess], aliases: true)`, else `JSON.parse`, then `.to_h` (string keys, jsonb-storable). Blank → nil; an unparseable value raises (base rescue names the legacy id). All 948 real values verified to normalize to `{"title"=>…, "authors"=>…}`. (Discovered at e2e — the fail-loud guard correctly halted on the first YAML row rather than storing junk.)
 - **D-no-finalize — none.** No counter caches on `lists`/`list_items`; sequence already reserved (no `setval`).
 
 ## Schema change

--- a/docs/superpowers/specs/2026-07-09-books-lists-migration-design.md
+++ b/docs/superpowers/specs/2026-07-09-books-lists-migration-design.md
@@ -1,0 +1,134 @@
+# Lists Migration (legacy `lists` + `list_items`) — Design
+
+**Status:** Approved 2026-07-09.
+**Scope:** Increment **2a** of Phase 2 (lists & rankings). Migrate the legacy `lists` table into the STI `Books::List` (**preserving ids**) and `list_items` into the polymorphic `list_items` (fresh ids, `listable = Books::Book`). No schema change. Unblocks 2b (ranking_configurations reference `lists` via `primary/secondary_mapped_list_id`; `ranked_lists` via `list_id`) and 2c (`list_penalties.list_id`).
+**Parent design:** `docs/superpowers/specs/2026-07-03-old-site-data-migration-design.md` (§Lists, §Enum re-encoding cheatsheet).
+**Depends on (all merged):** users (`submitted_by_id`), books (`list_items.listable = Books::Book`), and the Phase-0 `lists` id-range reservation (existing app lists sit at id ≥ 10,001; legacy ids 1–1,175 fit below with no collision, so **no `setval`**).
+
+## Goal
+
+Get all 1,030 legacy lists into `Books::List` with **ids preserved** and all 65,252 legacy `list_items` into `list_items`, faithfully, idempotently, and re-runnably.
+
+## Legacy data (local restore, introspected 2026-07-09)
+
+`lists`: **1,030 rows, max id 1,175**. `list_items`: **65,252 rows**. No `type` column on legacy `lists` (books-only app → constant `"Books::List"`).
+
+Facts that drive the design:
+
+| Fact | Value | Handling |
+|---|---|---|
+| `lists.status` distribution (old enum) | unapproved(0) 243, approved(1) 14, **active(2) 759**, rejected(3) 5, inactive(4) 3, pending(5) 6; **0 null** | **symbol-remap** (D-status) — a raw int copy would corrupt 759 `active`→`rejected` |
+| `lists.name` | all present | direct (model requires presence) |
+| `lists.url` | all present, **0 fail** the model's RFC2396 format | direct |
+| `lists.estimated_quality` | all present (0 null) | direct (new col NOT NULL default 0) |
+| `submitted_by_id` | 209 rows set / 11 distinct submitters, **0 missing** from migrated `User` | direct; fail-loud DB FK |
+| `formatted_text` / `unformatted_text` | **627** / **0** populated | `simplified_content ← formatted_text`; `unformatted_text` ignored (always empty) |
+| `raw_html` | **157** populated; **475 lists have formatted_text but blank raw_html** | `raw_content ← raw_html`; regenerating from raw_html would lose those 475 → **preserve** (D-simplified) |
+| `books_json` (jsonb) | 567 null, 386 JSON-string (180 empty `""`), **77 real arrays** | **skipped** → `items_json` nil (D-items-json); real items live in `list_items` |
+| `list_items.book_id` (nullable) | **0 null** | **no pending items** — `listable` is always a `Books::Book` |
+| `list_items` orphan `list_id` | **0** | every item's list is among the 1,030 |
+| `list_items` `book_id` missing from `Books::Book` | **0** of 24,362 distinct | fail-loud guard (D-li-failloud) |
+| duplicate `[list_id, book_id]` | **0** | natural key clean → safe upsert, no intra-batch conflict |
+| `list_items.position` | 38,183 null (58%), **0 ≤ 0** | null→null (model allows blank; non-null all > 0) |
+| `pending_book_data` (text, JSON) | 948 non-blank (e.g. `{"title":…,"authors":…}`) | `metadata ← parse(pending_book_data)` |
+| `list_items.verified` | no legacy column | default `false` |
+| timestamps | `lists` and `list_items` `created_at` span years | **preserved** |
+
+## Decisions
+
+- **D-write-lists — `BulkUpsertMigrator` keyed on `:id`** (like `UserMigrator`). Lists preserve id, and bulk `upsert_all` **bypasses the `List` callbacks** — crucially `before_save :auto_simplify_content`, which would overwrite `simplified_content` by re-running `Services::Html::SimplifierService` on `raw_content` (see D-simplified) — and the validations. Legacy `created_at`/`updated_at` preserved (`record_timestamps?` = false). Idempotent on `id`.
+- **D-status — symbol-remap** old `{unapproved:0, approved:1, active:2, rejected:3, inactive:4, pending:5}` → new `{unapproved:0, approved:1, rejected:2, active:3}` via the explicit map `{0=>0, 1=>1, 2=>3, 3=>2, 4=>0, 5=>0}` (inactive/pending have no new equivalent → `unapproved`). The migrator **raises** on any status int not in the map (fail-loud; all 1,030 rows are 0–5 today).
+- **D-simplified — preserve legacy `formatted_text`** (owner decision, 2026-07-09): `simplified_content ← formatted_text`, `raw_content ← raw_html`. Regenerating `simplified_content` from `raw_html` via the new simplifier would set it nil for the 475 lists that have `formatted_text` but no `raw_html`. Bulk upsert (D-write-lists) is what makes preservation possible (the callback is bypassed). `unformatted_text` is always empty and ignored.
+- **D-items-json — skip `books_json`** (owner decision, 2026-07-09): `items_json` is left **nil** for all lists. `books_json` is ~55% null / ~17% empty-string / only 7.5% real arrays, and the authoritative, structured item data is migrated into `list_items`. Avoids storing junk that would fail `items_json_format` on any later AR edit.
+- **D-write-list-items — `BulkUpsertMigrator`** on the unique index `[list_id, listable_type, listable_id]` (like `CategoryItemMigrator`). All 65,252 rows have a non-null `book_id`, so there are **no NULL-in-unique-index** rows (Postgres treats NULLs as distinct, which would break upsert idempotency) and **no pending items**. The **0 duplicate `[list_id, book_id]`** finding guarantees no intra-batch `ON CONFLICT` double-touch. Legacy timestamps preserved.
+- **D-li-failloud — guard the polymorphic `listable`.** `list_items.listable` has no DB FK (polymorphic), so a `book_id` with no migrated `Books::Book` would silently create a dangling item. `preload_context` loads the `Books::Book` id set; `build_rows` **raises** naming the legacy `list_item` id + `book_id` if the book is missing (mirrors `CategoryItemMigrator`). `list_id` has a real DB FK to `lists` (all present; lists migrate first).
+- **D-metadata — parse `pending_book_data` to a Hash** before upsert (plain jsonb column; a raw string would store as a jsonb string scalar). Blank → nil; malformed JSON raises (base rescue names the legacy id). Mirrors `UserMigrator#parse_provider_data`.
+- **D-no-finalize — none.** No counter caches on `lists`/`list_items`; sequence already reserved (no `setval`).
+
+## Schema change
+
+**None.** `lists` and `list_items` already have every needed column. No new index.
+
+## Source → target mapping
+
+### `lists` → `lists` (preserve id, `type = "Books::List"`)
+
+| new column | legacy source | handling |
+|---|---|---|
+| `id` | `id` | **preserved** (unique_by :id) |
+| `type` | (constant) | `"Books::List"` |
+| `name` | `name` | direct |
+| `description` | `description` | direct |
+| `source` | `source` | direct |
+| `url` | `url` | direct (all valid) |
+| `status` | `status` | **symbol-remap** `{0=>0,1=>1,2=>3,3=>2,4=>0,5=>0}` (D-status) |
+| `year_published` | `year_published` | direct |
+| `number_of_voters` | `number_of_voters` | direct |
+| `estimated_quality` | `estimated_quality` | direct (NOT NULL; all present) |
+| `submitted_by_id` | `submitted_by_id` | direct (users preserved; DB FK) |
+| `high_quality_source`, `category_specific`, `location_specific`, `yearly_award`, `voter_count_unknown`, `voter_names_unknown` | same names | direct (null→null) |
+| `raw_content` | `raw_html` | direct |
+| `simplified_content` | `formatted_text` | direct (D-simplified) |
+| `items_json` | — | **nil** (D-items-json) |
+| `created_at` / `updated_at` | same | **preserved** |
+
+Left null/default (no legacy equivalent): `creator_specific`, `num_years_covered`, `source_country_origin`, `voter_count_estimated`, `wizard_state`, `musicbrainz_series_id`.
+Dropped legacy columns: `lp_css_selector_mappings`, `ranked`, `ai_generated_description`, `percentage_western`, `unformatted_text` (empty).
+
+### `list_items` → `list_items` (fresh id, natural key `[list_id, listable_type, listable_id]`)
+
+| new column | legacy source | handling |
+|---|---|---|
+| `id` | — | fresh (auto) |
+| `list_id` | `list_id` | direct (lists preserve id; DB FK) |
+| `listable_type` | (constant) | `"Books::Book"` |
+| `listable_id` | `book_id` | direct (books preserve id); fail-loud guard (D-li-failloud) |
+| `position` | `position` | direct (null→null) |
+| `metadata` | `pending_book_data` | **parsed** to Hash (D-metadata); blank → nil |
+| `verified` | — | `false` |
+| `created_at` / `updated_at` | same | **preserved** |
+
+## Migrators
+
+- **`Services::BooksMigration::ListMigrator`** — `BulkUpsertMigrator`: `legacy_model = LegacyBooks::List` (new read-only model, `table_name = "lists"`), `target_model = List`, `unique_by: :id`, `record_timestamps?` = false. `build_rows` maps per the table above with a private `remap_status` (explicit hash, raises on unknown) — inline, mirroring `UserMigrator` (no separate transformer for bulk migrators). No `finalize`.
+- **`Services::BooksMigration::ListItemMigrator`** — `BulkUpsertMigrator`: `legacy_model = LegacyBooks::ListItem` (`table_name = "list_items"`), `target_model = ListItem`, `unique_by: :index_list_items_on_list_and_listable_unique`, `record_timestamps?` = false. `preload_context` builds the `Books::Book` id set; `build_rows` sets `listable = Books::Book`, parses `pending_book_data`, and raises on a missing book (D-li-failloud). No `finalize`.
+- New read-only legacy models `LegacyBooks::List` and `LegacyBooks::ListItem`.
+
+## Orchestration
+
+Add `data_migration:lists` (→ `ListMigrator.call`) and `data_migration:list_items` (→ `ListItemMigrator.call`). Insert into `data_migration:all` after the existing entries, **`:lists` before `:list_items`** (list_items' FK + guard need lists + books), e.g. `[…, :category_items, :external_links, :lists, :list_items]`.
+
+## Testing (Minitest + Mocha, stub `legacy_each`)
+
+**ListMigrator:**
+- Maps a fully-populated legacy list → `Books::List` with id preserved, `type = "Books::List"`, `raw_content ← raw_html`, `simplified_content ← formatted_text`, `items_json` nil, booleans + submitter direct, timestamps preserved.
+- **status remap:** each of 0–5 → correct new value (`2→active(3)`, `3→rejected(2)`, `4→unapproved`, `5→unapproved`); an unknown status int **raises** (result `success: false`, error names the legacy id).
+- `auto_simplify_content` does **not** run: a list with `raw_html` present keeps `simplified_content` = the legacy `formatted_text` (not the simplifier's output) — proves the callback is bypassed.
+- Idempotent: re-run leaves `List.count` unchanged, updates in place.
+
+**ListItemMigrator:**
+- Maps a legacy item → `list_items` row: `listable` = the `Books::Book`, `list_id` preserved, `position` direct, `verified` false, `metadata` = parsed `pending_book_data`, timestamps preserved.
+- Null `position` and blank `pending_book_data` → null `position` / nil `metadata`.
+- **Fail-loud:** a `book_id` with no `Books::Book` → `success: false`, error names the legacy `list_item` id.
+- Idempotent on `[list_id, listable]`: re-run leaves count unchanged, no duplicates.
+
+## E2e verification (controller-run against the real legacy DB)
+
+Reset dev DB to the migrated baseline, run `data_migration:lists` then `:list_items` (twice), then verify:
+- `List.where(type: "Books::List").count == 1030`; ids 1–1,175 present; **no collision** with the reserved ≥10,001 app lists.
+- `status` distribution: `{unapproved: 252, approved: 14, rejected: 5, active: 759}` (252 = 243 unapproved + 3 inactive + 6 pending).
+- `simplified_content` present on 627; `raw_content` present on 157; `items_json` null on all 1,030; timestamps preserved.
+- `ListItem.where(listable_type: "Books::Book").count == 65252`; 0 rows with a null/dangling `listable_id`; `metadata` present on 948; distinct `list_id` = 761.
+- Idempotent: second run leaves both counts unchanged.
+- Full suite green; `standardrb` + `brakeman` clean (0 new).
+
+## Out of scope
+- `ranking_configurations`, `ranked_lists` (2b); penalties (2c).
+- `books_json → items_json` (D-items-json); `ranked`, `lp_css_selector_mappings`, `ai_generated_description`, `percentage_western`.
+- Re-simplifying `raw_html` through the new simplifier (D-simplified).
+
+## References
+- Parent design: `docs/superpowers/specs/2026-07-03-old-site-data-migration-design.md`
+- Prior increment (template): `docs/superpowers/specs/2026-07-07-users-migration-design.md` (bulk, preserve id, timestamps) · `category_item_migrator.rb` (bulk join + fail-loud guard)
+- `BulkUpsertMigrator`: `app/lib/services/books_migration/bulk_upsert_migrator.rb`
+- `List` / `Books::List`: `app/models/list.rb`, `app/models/books/list.rb`; `ListItem`: `app/models/list_item.rb`

--- a/web-app/app/lib/services/books_migration/list_item_migrator.rb
+++ b/web-app/app/lib/services/books_migration/list_item_migrator.rb
@@ -1,0 +1,63 @@
+module Services
+  module BooksMigration
+    # Legacy `list_items` -> polymorphic list_items (listable = Books::Book), fresh id.
+    # Bulk upsert on the natural-key unique index [list_id, listable_type, listable_id].
+    # Every legacy row has a non-null book_id (no pending items), so there are no
+    # NULL-in-unique-index rows and (since [list_id, book_id] is unique in the source) no
+    # intra-batch ON CONFLICT double-touch. listable has no DB FK (polymorphic), so a
+    # book_id with no migrated Books::Book is a fail-loud raise naming the legacy
+    # list_item id (preloaded id set). metadata <- parsed pending_book_data (plain jsonb;
+    # a raw string would store as a jsonb string scalar). verified defaults false. Legacy
+    # created_at/updated_at preserved.
+    class ListItemMigrator < BulkUpsertMigrator
+      private
+
+      def legacy_model
+        LegacyBooks::ListItem
+      end
+
+      def model_key
+        "ListItem"
+      end
+
+      def target_model
+        ListItem
+      end
+
+      def unique_by
+        :index_list_items_on_list_and_listable_unique
+      end
+
+      def record_timestamps?
+        false
+      end
+
+      def preload_context
+        @book_ids = Books::Book.pluck(:id).to_set
+      end
+
+      def build_rows(attrs)
+        book_id = attrs["book_id"]
+        unless @book_ids.include?(book_id)
+          raise "no migrated Books::Book for legacy list_items.book_id=#{book_id.inspect} (list_item id=#{attrs["id"]})"
+        end
+
+        [{
+          list_id: attrs["list_id"],
+          listable_type: "Books::Book",
+          listable_id: book_id,
+          position: attrs["position"],
+          metadata: parse_metadata(attrs["pending_book_data"]),
+          verified: false,
+          created_at: attrs["created_at"],
+          updated_at: attrs["updated_at"]
+        }]
+      end
+
+      def parse_metadata(value)
+        return nil if value.blank?
+        JSON.parse(value)
+      end
+    end
+  end
+end

--- a/web-app/app/lib/services/books_migration/list_item_migrator.rb
+++ b/web-app/app/lib/services/books_migration/list_item_migrator.rb
@@ -6,8 +6,9 @@ module Services
     # NULL-in-unique-index rows and (since [list_id, book_id] is unique in the source) no
     # intra-batch ON CONFLICT double-touch. listable has no DB FK (polymorphic), so a
     # book_id with no migrated Books::Book is a fail-loud raise naming the legacy
-    # list_item id (preloaded id set). metadata <- parsed pending_book_data (plain jsonb;
-    # a raw string would store as a jsonb string scalar). verified defaults false. Legacy
+    # list_item id (preloaded id set). metadata <- pending_book_data parsed from either
+    # JSON or YAML (legacy serialize drift) into a plain Hash (plain jsonb; a raw string
+    # would store as a jsonb string scalar). verified defaults false. Legacy
     # created_at/updated_at preserved.
     class ListItemMigrator < BulkUpsertMigrator
       private
@@ -56,7 +57,13 @@ module Services
 
       def parse_metadata(value)
         return nil if value.blank?
-        JSON.parse(value)
+        str = value.strip
+        parsed = if str.start_with?("---")
+          YAML.safe_load(str, permitted_classes: [Symbol, ActiveSupport::HashWithIndifferentAccess], aliases: true)
+        else
+          JSON.parse(str)
+        end
+        parsed.to_h
       end
     end
   end

--- a/web-app/app/lib/services/books_migration/list_migrator.rb
+++ b/web-app/app/lib/services/books_migration/list_migrator.rb
@@ -9,8 +9,6 @@ module Services
     # (nil; real items live in list_items). Legacy created_at/updated_at preserved.
     # Idempotent on id.
     class ListMigrator < BulkUpsertMigrator
-      # old {unapproved:0, approved:1, active:2, rejected:3, inactive:4, pending:5}
-      # new {unapproved:0, approved:1, rejected:2, active:3}
       STATUS_MAP = {0 => 0, 1 => 1, 2 => 3, 3 => 2, 4 => 0, 5 => 0}.freeze
 
       private

--- a/web-app/app/lib/services/books_migration/list_migrator.rb
+++ b/web-app/app/lib/services/books_migration/list_migrator.rb
@@ -1,0 +1,69 @@
+module Services
+  module BooksMigration
+    # Legacy `lists` -> STI Books::List, preserving id. Bulk upsert_all bypasses the List
+    # callbacks — crucially before_save :auto_simplify_content, which would re-run the HTML
+    # simplifier over raw_content and overwrite the legacy formatted_text we preserve as
+    # simplified_content — and the validations. status is symbol-remapped (old/new enums
+    # differ: active/rejected swap ints, inactive/pending collapse to unapproved).
+    # raw_content <- raw_html, simplified_content <- formatted_text, items_json skipped
+    # (nil; real items live in list_items). Legacy created_at/updated_at preserved.
+    # Idempotent on id.
+    class ListMigrator < BulkUpsertMigrator
+      # old {unapproved:0, approved:1, active:2, rejected:3, inactive:4, pending:5}
+      # new {unapproved:0, approved:1, rejected:2, active:3}
+      STATUS_MAP = {0 => 0, 1 => 1, 2 => 3, 3 => 2, 4 => 0, 5 => 0}.freeze
+
+      private
+
+      def legacy_model
+        LegacyBooks::List
+      end
+
+      def model_key
+        "Books::List"
+      end
+
+      def target_model
+        List
+      end
+
+      def unique_by
+        :id
+      end
+
+      def record_timestamps?
+        false
+      end
+
+      def build_rows(attrs)
+        [{
+          id: attrs["id"],
+          type: "Books::List",
+          name: attrs["name"],
+          description: attrs["description"],
+          source: attrs["source"],
+          url: attrs["url"],
+          status: remap_status(attrs["status"]),
+          year_published: attrs["year_published"],
+          number_of_voters: attrs["number_of_voters"],
+          estimated_quality: attrs["estimated_quality"],
+          submitted_by_id: attrs["submitted_by_id"],
+          high_quality_source: attrs["high_quality_source"],
+          category_specific: attrs["category_specific"],
+          location_specific: attrs["location_specific"],
+          yearly_award: attrs["yearly_award"],
+          voter_count_unknown: attrs["voter_count_unknown"],
+          voter_names_unknown: attrs["voter_names_unknown"],
+          raw_content: attrs["raw_html"],
+          simplified_content: attrs["formatted_text"],
+          created_at: attrs["created_at"],
+          updated_at: attrs["updated_at"]
+        }]
+      end
+
+      def remap_status(old)
+        STATUS_MAP.fetch(old) { raise "unmapped legacy lists.status=#{old.inspect}" }
+      end
+    end
+  end
+end

--- a/web-app/app/models/legacy_books/list.rb
+++ b/web-app/app/models/legacy_books/list.rb
@@ -1,0 +1,5 @@
+module LegacyBooks
+  class List < Record
+    self.table_name = "lists"
+  end
+end

--- a/web-app/app/models/legacy_books/list_item.rb
+++ b/web-app/app/models/legacy_books/list_item.rb
@@ -1,0 +1,5 @@
+module LegacyBooks
+  class ListItem < Record
+    self.table_name = "list_items"
+  end
+end

--- a/web-app/lib/tasks/data_migration.rake
+++ b/web-app/lib/tasks/data_migration.rake
@@ -53,6 +53,16 @@ namespace :data_migration do
     pp Services::BooksMigration::ExternalLinkMigrator.call
   end
 
+  desc "Migrate legacy lists into Books::List (preserve id; status symbol-remap)"
+  task lists: :environment do
+    pp Services::BooksMigration::ListMigrator.call
+  end
+
+  desc "Migrate legacy list_items into list_items (listable = Books::Book; fresh id)"
+  task list_items: :environment do
+    pp Services::BooksMigration::ListItemMigrator.call
+  end
+
   desc "Run all Phase-1 migrators in dependency order"
-  task all: [:languages, :users, :authors, :books, :book_authors, :editions, :identifiers, :categories, :category_items, :external_links]
+  task all: [:languages, :users, :authors, :books, :book_authors, :editions, :identifiers, :categories, :category_items, :external_links, :lists, :list_items]
 end

--- a/web-app/test/lib/services/books_migration/list_item_migrator_test.rb
+++ b/web-app/test/lib/services/books_migration/list_item_migrator_test.rb
@@ -50,6 +50,14 @@ module Services
         assert_equal({"title" => "T", "authors" => "A"}, item.metadata)
       end
 
+      test "parses YAML-serialized pending_book_data into metadata" do
+        yaml = "--- !ruby/hash:ActiveSupport::HashWithIndifferentAccess\ntitle: Dune\nauthors: Frank Herbert\n"
+        run_migrator([legacy_row("pending_book_data" => yaml)])
+
+        item = ListItem.find_by(list_id: @list.id, listable_id: @book.id)
+        assert_equal({"title" => "Dune", "authors" => "Frank Herbert"}, item.metadata)
+      end
+
       test "null position and blank pending_book_data become nil" do
         run_migrator([legacy_row("position" => nil, "pending_book_data" => "")])
 

--- a/web-app/test/lib/services/books_migration/list_item_migrator_test.rb
+++ b/web-app/test/lib/services/books_migration/list_item_migrator_test.rb
@@ -1,0 +1,79 @@
+require "test_helper"
+
+module Services
+  module BooksMigration
+    class ListItemMigratorTest < ActiveSupport::TestCase
+      setup do
+        @list = Books::List.create!(name: "Item Parent List")
+        @book = Books::Book.create!(title: "Item Book")
+      end
+
+      def run_migrator(rows)
+        migrator = ListItemMigrator.new
+        migrator.stubs(:legacy_each).multiple_yields(*rows.zip)
+        migrator.call
+      end
+
+      def legacy_row(overrides = {})
+        {
+          "id" => 8000001,
+          "list_id" => @list.id,
+          "book_id" => @book.id,
+          "position" => 3,
+          "pending_book_data" => nil,
+          "created_at" => Time.utc(2018, 5, 6, 7, 8, 9),
+          "updated_at" => Time.utc(2019, 6, 7, 8, 9, 10)
+        }.merge(overrides)
+      end
+
+      test "maps a legacy list_item to a Books::Book listable" do
+        result = run_migrator([legacy_row])
+
+        assert result[:success], result[:error]
+        assert_equal 1, result[:data][:count]
+        assert_equal "ListItem", result[:data][:model]
+
+        item = ListItem.find_by(list_id: @list.id, listable_type: "Books::Book", listable_id: @book.id)
+        assert_not_nil item
+        assert_equal @book, item.listable
+        assert_equal 3, item.position
+        assert_equal false, item.verified
+        assert_nil item.metadata
+        assert_equal Time.utc(2018, 5, 6, 7, 8, 9), item.created_at
+        assert_equal Time.utc(2019, 6, 7, 8, 9, 10), item.updated_at
+      end
+
+      test "parses pending_book_data into metadata" do
+        run_migrator([legacy_row("pending_book_data" => '{"title":"T","authors":"A"}')])
+
+        item = ListItem.find_by(list_id: @list.id, listable_id: @book.id)
+        assert_equal({"title" => "T", "authors" => "A"}, item.metadata)
+      end
+
+      test "null position and blank pending_book_data become nil" do
+        run_migrator([legacy_row("position" => nil, "pending_book_data" => "")])
+
+        item = ListItem.find_by(list_id: @list.id, listable_id: @book.id)
+        assert_nil item.position
+        assert_nil item.metadata
+      end
+
+      test "fails loud when the book is not migrated" do
+        missing = Books::Book.maximum(:id).to_i + 999_999
+        result = run_migrator([legacy_row("id" => 8000042, "book_id" => missing)])
+
+        refute result[:success]
+        assert_match(/8000042/, result[:error])
+      end
+
+      test "is idempotent on [list, listable]" do
+        run_migrator([legacy_row])
+
+        assert_no_difference -> { ListItem.count } do
+          run_migrator([legacy_row("position" => 99)])
+        end
+        assert_equal 99, ListItem.find_by(list_id: @list.id, listable_id: @book.id).position
+      end
+    end
+  end
+end

--- a/web-app/test/lib/services/books_migration/list_migrator_test.rb
+++ b/web-app/test/lib/services/books_migration/list_migrator_test.rb
@@ -1,0 +1,100 @@
+require "test_helper"
+
+module Services
+  module BooksMigration
+    class ListMigratorTest < ActiveSupport::TestCase
+      setup do
+        @user = users(:regular_user)
+      end
+
+      def run_migrator(rows)
+        migrator = ListMigrator.new
+        migrator.stubs(:legacy_each).multiple_yields(*rows.zip)
+        migrator.call
+      end
+
+      def legacy_row(overrides = {})
+        {
+          "id" => 990001,
+          "name" => "Best Books",
+          "description" => "desc",
+          "source" => "example.com",
+          "url" => "https://example.com/list",
+          "status" => 2,
+          "year_published" => 2020,
+          "number_of_voters" => 100,
+          "estimated_quality" => 5,
+          "submitted_by_id" => @user.id,
+          "high_quality_source" => true,
+          "category_specific" => false,
+          "location_specific" => nil,
+          "yearly_award" => false,
+          "voter_count_unknown" => nil,
+          "voter_names_unknown" => nil,
+          "raw_html" => "<ol><li>A</li></ol>",
+          "formatted_text" => "A",
+          "created_at" => Time.utc(2015, 1, 2, 3, 4, 5),
+          "updated_at" => Time.utc(2016, 2, 3, 4, 5, 6)
+        }.merge(overrides)
+      end
+
+      test "maps a legacy list to Books::List, preserving id" do
+        result = run_migrator([legacy_row])
+
+        assert result[:success], result[:error]
+        assert_equal 1, result[:data][:count]
+        assert_equal "Books::List", result[:data][:model]
+
+        list = List.find(990001)
+        assert_instance_of Books::List, list
+        assert_equal "Best Books", list.name
+        assert_equal "desc", list.description
+        assert_equal "example.com", list.source
+        assert_equal "https://example.com/list", list.url
+        assert list.active?
+        assert_equal 2020, list.year_published
+        assert_equal 100, list.number_of_voters
+        assert_equal 5, list.estimated_quality
+        assert_equal @user, list.submitted_by
+        assert_equal true, list.high_quality_source
+        assert_equal false, list.category_specific
+        assert_nil list.location_specific
+        assert_equal "<ol><li>A</li></ol>", list.raw_content
+        assert_equal "A", list.simplified_content
+        assert_nil list.items_json
+        assert_equal Time.utc(2015, 1, 2, 3, 4, 5), list.created_at
+        assert_equal Time.utc(2016, 2, 3, 4, 5, 6), list.updated_at
+      end
+
+      test "remaps status by symbol" do
+        expected = {0 => "unapproved", 1 => "approved", 2 => "active", 3 => "rejected", 4 => "unapproved", 5 => "unapproved"}
+        expected.each_with_index do |(old, want), i|
+          run_migrator([legacy_row("id" => 991000 + i, "status" => old)])
+          assert_equal want, List.find(991000 + i).status, "old status #{old}"
+        end
+      end
+
+      test "does not run auto_simplify_content (preserves legacy formatted_text)" do
+        run_migrator([legacy_row("id" => 992001, "raw_html" => "<div><script>x</script>Hello</div>", "formatted_text" => "LEGACY")])
+
+        assert_equal "LEGACY", List.find(992001).simplified_content
+      end
+
+      test "fails loud on an unmapped status" do
+        result = run_migrator([legacy_row("id" => 993001, "status" => 9)])
+
+        refute result[:success]
+        assert_match(/993001/, result[:error])
+      end
+
+      test "is idempotent on id" do
+        run_migrator([legacy_row("id" => 994001)])
+
+        assert_no_difference -> { List.count } do
+          run_migrator([legacy_row("id" => 994001, "name" => "Renamed")])
+        end
+        assert_equal "Renamed", List.find(994001).name
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Increment **2a** of Phase 2 (lists & rankings) of the legacy TheGreatestBooks → new app data migration. Migrates legacy `lists` (1,030) into the STI `Books::List` (**preserving ids**) and legacy `list_items` (65,252) into the polymorphic `list_items` (`listable = Books::Book`, fresh ids). No schema change.

Phase 2 was decomposed (owner-approved) into 2a lists+list_items → 2b ranking_configurations+ranked_lists → 2c penalties. This is 2a.

## What the real legacy data looks like (introspected)

- No `type` column on legacy `lists` (books-only app) → constant `"Books::List"`.
- **`status` is the landmine:** old `{unapproved:0, approved:1, active:2, rejected:3, inactive:4, pending:5}` → new `{unapproved:0, approved:1, rejected:2, active:3}`. **759 rows are `active(2)`** — a raw int copy would corrupt them to `rejected`. Remapped by symbol.
- `simplified_content`: `formatted_text` on 627 lists, but `raw_html` on only 157 — and **475 lists have `formatted_text` with no `raw_html`**, so regenerating via the simplifier would lose them. Preserved verbatim.
- `list_items`: **zero pending items** (every row has a valid `book_id`), zero orphans, zero duplicate `[list_id, book_id]`.
- **`pending_book_data` is mixed serialization** — 546 JSON objects + 402 YAML (`--- !ruby/hash:ActiveSupport::HashWithIndifferentAccess`), legacy Rails `serialize` drift. Parsed from both formats.

## Design

- Both migrators are `BulkUpsertMigrator` subclasses (`record_timestamps? false`, preserve legacy timestamps).
- **`ListMigrator`** — keyed on `:id` (preserve id, bypass the `List` callbacks so `auto_simplify_content` can't overwrite the preserved `formatted_text`, and validations). Status symbol-remap `{0=>0,1=>1,2=>3,3=>2,4=>0,5=>0}` with a **fail-loud raise** on any unmapped value. `raw_content ← raw_html`; `simplified_content ← formatted_text`; `items_json` left nil (legacy `books_json` is mostly null/empty; real items live in `list_items`).
- **`ListItemMigrator`** — upsert on the natural-key unique index `[list_id, listable_type, listable_id]`. `listable = Books::Book`; `metadata ← parse(pending_book_data)` handling **both JSON and YAML** → plain string-keyed Hash. **Fail-loud** on a `book_id` with no migrated `Books::Book` via a preloaded id set (the polymorphic `listable` has no DB FK).
- No sequence reset needed (legacy list ids 1–1,175 sit below the reserved ≥10,001 app-list range from Phase 0).

## Verification

- **Unit:** `ListMigrator` 5 tests (mapping, status remap for all six old values, callback-bypass proof, fail-loud on unmapped status, idempotency); `ListItemMigrator` 6 tests (mapping, JSON metadata, YAML metadata, null/blank, fail-loud missing book, idempotency). Full suite **4453 runs, 0 failures/errors/skips**; standardrb clean; brakeman at baseline (0 new).
- **E2E (real legacy DB, run twice):** `lists` `{success: true, count: 1030}`, `list_items` `{success: true, count: 65252}`. `Books::List` 0 → 1,030 (ids 1–1,175, reserved ≥10,001 app lists untouched); status distribution exactly `{unapproved: 252, approved: 14, rejected: 5, active: 759}`; `simplified_content` on 627, `raw_content` on 157, `items_json` null on all; `ListItem` `Books::Book` 0 → 65,252; `metadata` on 948 (both JSON+YAML parsed); zero dangling listables; timestamps preserved; the pre-existing Music/Games list rows untouched. Second run byte-identical (idempotent).

## Notes
- The YAML/`pending_book_data` case surfaced *during* the e2e — the fail-loud guard correctly halted on the first YAML row rather than storing junk, and the fix was verified against all 948 real values (0 parse errors). `YAML.safe_load` with an explicit non-executable class allowlist (no brakeman impact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
