### PR TITLE
Books admin 6b: lists + ranking-configurations + legacy date-penalty parity

### DIFF
--- a/docs/superpowers/plans/2026-07-22-books-admin-6b-lists-rankings.md
+++ b/docs/superpowers/plans/2026-07-22-books-admin-6b-lists-rankings.md
@@ -16,7 +16,7 @@
 - Check actual fixture names before referencing; auth in integration tests via `sign_in_as(user, stub_auth: true)`; turbo/JSON requests use `as: :turbo_stream` / `as: :json`.
 - `raise_on_missing_callback_actions` is ON in dev+test — never name an action in a `before_action only: […]` list before it exists.
 - **STI subclasses have no per-model fixtures** (a `test/fixtures/books/lists.yml` would break the suite). Use the shared `test/fixtures/lists.yml` (which has `Books::List` rows) or build records in-test (the games controller tests build lists in-test — mirror that).
-- **`ItemRankings::Calculator#calculate_score_penalty` is `private`.** The parity fix is the crux of this increment and its exact per-branch values can't be isolated through the public `call` (the penalty is one input among list weight/position/bonus-pool to the WeightedListRank gem). Task 2 therefore verifies the branch parity by calling the method via `send` — a deliberate, scoped exception to "never test private methods," because it directly pins legacy behavior.
+- **The legacy date-penalty math is extracted to a public `ItemRankings::DatePenalty` PORO** (Task 2) and unit-tested directly — the calculator's private `calculate_score_penalty` becomes a thin adapter. No private methods are tested; the adapter wiring is covered by the existing public `call`-based calculator tests.
 - The date penalty only runs when `ranking_configuration.apply_list_dates_penalty?` is true (`item_rankings/calculator.rb:80`).
 - Verify with `bin/rails test` (+ `test:system` for UI) and `bundle exec standardrb`; Playwright via `yarn test:e2e`.
 - Commit messages end with `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>`. Branch `books-admin-6b` (already created off main).
@@ -90,22 +90,22 @@ EOF
 
 ---
 
-### Task 2: Legacy date-penalty parity in the shared `ItemRankings::Calculator`
+### Task 2: Legacy date-penalty parity — extract `ItemRankings::DatePenalty` + wire it in
 
-Reproduce the legacy TheGreatestBooks date penalty: a yearly-award list, or an item with no publication year, takes the full penalty — checked **before** the `list.year_published` guard (legacy order). This is a shared change (all domains); it's inert for music/games award lists (0 exist) and re-ranks ~1% of their nil-year items.
+Reproduce the legacy TheGreatestBooks date penalty: a yearly-award list, or an item with no publication year, takes the full penalty — checked **before** the `list.year_published` guard (legacy order). Extract the pure math into a public, unit-tested `ItemRankings::DatePenalty` PORO (owner call — no testing of private methods), and make the calculator's `calculate_score_penalty` a thin adapter. This is a shared change (all domains): inert for music/games award lists (0 exist), re-ranks ~1% of their nil-year items.
 
 **Files:**
-- Modify: `web-app/app/lib/item_rankings/calculator.rb` (rewrite `calculate_score_penalty`, ~line 90)
-- Test: `web-app/test/lib/item_rankings/books/calculator_test.rb` (create)
-- Test: `web-app/test/lib/item_rankings/music/albums/calculator_test.rb` (add one cross-domain assertion)
+- Create: `web-app/app/lib/item_rankings/date_penalty.rb`
+- Modify: `web-app/app/lib/item_rankings/calculator.rb` (`calculate_score_penalty` → adapter)
+- Test: `web-app/test/lib/item_rankings/date_penalty_test.rb` (create)
 
 **Interfaces:**
+- Produces: `ItemRankings::DatePenalty.call(list_year:, item_year:, yearly_award:, max_age:, max_penalty_percentage:) → Float | nil` — pure legacy math.
 - Consumes: `Books::Book#release_year` (Task 1); `ranking_configuration.{apply_list_dates_penalty?, max_list_dates_penalty_age, max_list_dates_penalty_percentage}`; `list.{year_published, yearly_award?}`; `list_item.listable`.
-- Produces: `ItemRankings::Calculator#calculate_score_penalty(list, list_item) → Float | nil` with legacy branch order.
 
-- [ ] **Step 1: Write the failing tests**
+- [ ] **Step 1: Write the failing PORO test**
 
-Create `web-app/test/lib/item_rankings/books/calculator_test.rb`:
+Create `web-app/test/lib/item_rankings/date_penalty_test.rb`:
 
 ```ruby
 # frozen_string_literal: true
@@ -113,82 +113,77 @@ Create `web-app/test/lib/item_rankings/books/calculator_test.rb`:
 require "test_helper"
 
 module ItemRankings
-  module Books
-    class CalculatorTest < ActiveSupport::TestCase
-      setup do
-        @rc = ranking_configurations(:books_global)
-        @rc.update!(apply_list_dates_penalty: true, max_list_dates_penalty_age: 50, max_list_dates_penalty_percentage: 80)
-        @calculator = ItemRankings::Books::Calculator.new(@rc)
-      end
+  class DatePenaltyTest < ActiveSupport::TestCase
+    def penalty(list_year: 2000, item_year: 1980, yearly_award: false, max_age: 50, max_penalty_percentage: 80)
+      ItemRankings::DatePenalty.call(
+        list_year: list_year, item_year: item_year, yearly_award: yearly_award,
+        max_age: max_age, max_penalty_percentage: max_penalty_percentage
+      )
+    end
 
-      def penalty_for(list_year:, first_published_year:, yearly_award: false)
-        list = ::Books::List.create!(name: "L#{rand(1_000_000)}", status: :approved, year_published: list_year, yearly_award: yearly_award)
-        book = ::Books::Book.create!(title: "B#{rand(1_000_000)}", first_published_year: first_published_year)
-        list_item = list.list_items.create!(listable: book, position: 1)
-        @calculator.send(:calculate_score_penalty, list, list_item)
-      end
+    test "graduated penalty for an item older than the list within max_age" do
+      # year_difference = 20; ((50-20)/50)*80/100 = 0.48
+      assert_in_delta 0.48, penalty(item_year: 1980), 0.0001
+    end
 
-      test "book older than the list within max_age gets a graduated penalty" do
-        # year_difference = 20; ((50-20)/50)*80/100 = 0.48
-        assert_in_delta 0.48, penalty_for(list_year: 2000, first_published_year: 1980), 0.0001
-      end
+    test "max penalty when the item is newer than the list" do
+      assert_in_delta 0.80, penalty(item_year: 2005), 0.0001
+    end
 
-      test "book newer than the list gets the max penalty" do
-        assert_in_delta 0.80, penalty_for(list_year: 2000, first_published_year: 2005), 0.0001
-      end
+    test "no penalty when the item is older than max_age" do
+      assert_nil penalty(item_year: 1940) # diff 60 > 50
+    end
 
-      test "book older than max_age gets no penalty" do
-        # year_difference = 60 > 50
-        assert_nil penalty_for(list_year: 2000, first_published_year: 1940)
-      end
+    test "max penalty when the item has no year" do
+      assert_in_delta 0.80, penalty(item_year: nil), 0.0001
+    end
 
-      test "item with no publication year gets the max penalty" do
-        assert_in_delta 0.80, penalty_for(list_year: 2000, first_published_year: nil), 0.0001
-      end
+    test "a yearly-award list forces max penalty even with a good year gap" do
+      assert_in_delta 0.80, penalty(item_year: 1940, yearly_award: true), 0.0001
+    end
 
-      test "a yearly-award list gives the item the max penalty even with a good year gap" do
-        # would otherwise be no penalty (diff 60 > 50); award forces max
-        assert_in_delta 0.80, penalty_for(list_year: 2000, first_published_year: 1940, yearly_award: true), 0.0001
-      end
+    test "a yearly-award list max-penalizes even with no list year" do
+      assert_in_delta 0.80, penalty(list_year: nil, item_year: 1980, yearly_award: true), 0.0001
+    end
 
-      test "a yearly-award list with no year_published still max-penalizes" do
-        assert_in_delta 0.80, penalty_for(list_year: nil, first_published_year: 1980, yearly_award: true), 0.0001
-      end
+    test "nil when the penalty config is incomplete" do
+      assert_nil penalty(max_age: nil)
+      assert_nil penalty(max_penalty_percentage: nil)
+    end
 
-      test "no penalty config yields nil" do
-        @rc.update!(max_list_dates_penalty_age: nil, max_list_dates_penalty_percentage: nil)
-        assert_nil penalty_for(list_year: 2000, first_published_year: 1990)
-      end
+    test "nil when the list has no year and the item is not award/nil-year" do
+      assert_nil penalty(list_year: nil)
     end
   end
 end
 ```
 
-- [ ] **Step 2: Run to verify failures**
+- [ ] **Step 2: Run to verify failure**
 
-Run: `bin/rails test test/lib/item_rankings/books/calculator_test.rb`
-Expected: FAIL — with the current code, `item with no publication year` returns `nil` (line 95 skip) not `0.80`; `yearly-award` cases don't force max; `yearly-award with no year_published` returns nil at the `list.year_published` guard.
+Run: `bin/rails test test/lib/item_rankings/date_penalty_test.rb`
+Expected: FAIL — `uninitialized constant ItemRankings::DatePenalty`.
 
-- [ ] **Step 3: Rewrite `calculate_score_penalty`**
+- [ ] **Step 3: Create the PORO**
 
-Replace the method in `web-app/app/lib/item_rankings/calculator.rb` (currently ~lines 90-115) with:
+Create `web-app/app/lib/item_rankings/date_penalty.rb`:
 
 ```ruby
-    def calculate_score_penalty(list, list_item)
-      max_age = ranking_configuration.max_list_dates_penalty_age
-      max_penalty_percentage = ranking_configuration.max_list_dates_penalty_percentage
+# frozen_string_literal: true
+
+module ItemRankings
+  # Pure legacy per-item "list dates" recency penalty, mirroring the legacy
+  # TheGreatestBooks calculate_score_penalty. Returns a penalty fraction (0..1)
+  # or nil (no penalty). Order matches legacy: award lists and items with an
+  # unknown year take the full penalty, checked before the list-year guard.
+  class DatePenalty
+    def self.call(list_year:, item_year:, yearly_award:, max_age:, max_penalty_percentage:)
       return nil if max_age.nil? || max_penalty_percentage.nil?
 
-      item = list_item.listable
-      item_year = (item.respond_to?(:release_year) ? item.release_year : nil)
+      return max_penalty_percentage / 100.0 if yearly_award || item_year.nil?
 
-      # Legacy parity: award lists and items with no known year take the full
-      # penalty, regardless of the list's own publication year (checked first).
-      return max_penalty_percentage / 100.0 if list.yearly_award? || item_year.nil?
+      return nil if list_year.nil?
 
-      return nil unless list.year_published.present?
-
-      year_difference = list.year_published - item_year
+      year_difference = list_year - item_year
 
       penalty = if year_difference <= 0
         max_penalty_percentage / 100.0
@@ -201,45 +196,55 @@ Replace the method in `web-app/app/lib/item_rankings/calculator.rb` (currently ~
 
       (penalty == 0) ? nil : penalty
     end
+  end
+end
 ```
 
-- [ ] **Step 4: Run books calculator test to verify pass**
+- [ ] **Step 4: Run the PORO test to verify pass**
 
-Run: `bin/rails test test/lib/item_rankings/books/calculator_test.rb`
-Expected: PASS (all 7).
+Run: `bin/rails test test/lib/item_rankings/date_penalty_test.rb`
+Expected: PASS (all 8).
 
-- [ ] **Step 5: Add the cross-domain assertion (shared behavior)**
+- [ ] **Step 5: Wire the calculator adapter to the PORO**
 
-Add to `web-app/test/lib/item_rankings/music/albums/calculator_test.rb` (inside the existing test class), pinning that the nil-year rule is shared, not books-only. Reuse the RC's already-wired fixture list/album (no fragile `create!`); `update_column` bypasses validations for the nil-year setup:
+Replace `calculate_score_penalty` in `web-app/app/lib/item_rankings/calculator.rb` (currently ~lines 90-115) with a thin adapter that extracts the values and delegates the math:
 
 ```ruby
-        test "an album with no release year gets the max penalty (shared date-penalty parity)" do
-          @ranking_configuration.update!(apply_list_dates_penalty: true, max_list_dates_penalty_age: 30, max_list_dates_penalty_percentage: 50)
-          list_item = @ranking_configuration.ranked_lists.first.list.list_items.first
-          list_item.list.update!(year_published: 2000)
-          list_item.listable.update_column(:release_year, nil)
-          assert_in_delta 0.50, @calculator.send(:calculate_score_penalty, list_item.list, list_item), 0.0001
-        end
+    def calculate_score_penalty(list, list_item)
+      item = list_item.listable
+      item_year = item.respond_to?(:release_year) ? item.release_year : nil
+
+      ItemRankings::DatePenalty.call(
+        list_year: list.year_published,
+        item_year: item_year,
+        yearly_award: list.yearly_award?,
+        max_age: ranking_configuration.max_list_dates_penalty_age,
+        max_penalty_percentage: ranking_configuration.max_list_dates_penalty_percentage
+      )
+    end
 ```
 
-- [ ] **Step 6: Run both calculator tests + full item_rankings suite**
+(The public `call`-based calculator tests — e.g. music albums' "call handles penalty calculations when enabled" — exercise this adapter end-to-end through `prepare_items`; they must stay green, confirming the adapter feeds `item.release_year`/`yearly_award?` correctly.)
+
+- [ ] **Step 6: Run the full item_rankings suite (adapter wiring + no regression)**
 
 Run: `bin/rails test test/lib/item_rankings/`
-Expected: PASS — no regressions in the existing music/movies/games calculator tests.
+Expected: PASS — the existing music/movies/games calculator `call` tests still pass, confirming the adapter refactor is behavior-preserving for the pre-existing cases.
 
 - [ ] **Step 7: standardrb + commit**
 
-Run: `bundle exec standardrb app/lib/item_rankings/calculator.rb test/lib/item_rankings/books/calculator_test.rb test/lib/item_rankings/music/albums/calculator_test.rb` → no offenses.
+Run: `bundle exec standardrb app/lib/item_rankings/date_penalty.rb app/lib/item_rankings/calculator.rb test/lib/item_rankings/date_penalty_test.rb` → no offenses.
 
 ```bash
-git add app/lib/item_rankings/calculator.rb test/lib/item_rankings/books/calculator_test.rb test/lib/item_rankings/music/albums/calculator_test.rb
+git add app/lib/item_rankings/date_penalty.rb app/lib/item_rankings/calculator.rb test/lib/item_rankings/date_penalty_test.rb
 git commit -m "$(cat <<'EOF'
-Match legacy date penalty: yearly-award + nil-year items take max penalty (inc 6b task 2)
+Extract ItemRankings::DatePenalty for legacy date-penalty parity (inc 6b task 2)
 
-Reproduces the legacy TheGreatestBooks calculate_score_penalty: a yearly-award
-list, or an item with no publication year, gets the full penalty, checked
-before the list.year_published guard. Shared across domains (inert for
-music/games award lists; re-ranks their nil-year items, ~1%).
+Pure PORO mirroring the legacy TheGreatestBooks calculate_score_penalty: a
+yearly-award list, or an item with no publication year, takes the full
+penalty, checked before the list.year_published guard. The calculator's
+calculate_score_penalty is now a thin adapter. Shared across domains (inert
+for music/games award lists; re-ranks their nil-year items, ~1%).
 
 Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
 EOF
@@ -820,7 +825,7 @@ EOF
 - [ ] `bin/rails test` — full suite green (baseline 4805/0 after 6a; expect that plus the new tests).
 - [ ] `bundle exec standardrb` — no offenses.
 - [ ] `yarn test:e2e e2e/tests/books/admin/lists.spec.ts e2e/tests/books/admin/ranking-configurations.spec.ts` — pass (dev server up).
-- [ ] Confirm the only edits to existing music/games tests are the two deliberate denial-test flips (Task 4) and the one shared-calculator assertion (Task 2). Any other change to an existing assertion is a red flag — stop and investigate.
+- [ ] Confirm the only edits to existing music/games tests are the two deliberate denial-test flips (Task 4). Task 2 refactors `calculate_score_penalty` into a `DatePenalty` adapter but changes no existing test. Any other change to an existing assertion is a red flag — stop and investigate.
 - [ ] Sanity-check the reframing held: `grep -rn "num_years_covered" app/` shows no books RC applies it; `calculate_books_year_range` was left untouched.
 
 ## Notes / carried context

--- a/docs/superpowers/plans/2026-07-22-books-admin-6b-lists-rankings.md
+++ b/docs/superpowers/plans/2026-07-22-books-admin-6b-lists-rankings.md
@@ -1,0 +1,829 @@
+# Books Admin — Increment 6b: Lists + Ranking Configurations + Legacy Date-Penalty Parity — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the books admin's Lists and Ranking-Configuration surfaces, and make the new books rankings reproduce the legacy TheGreatestBooks date penalty.
+
+**Architecture:** `Admin::Books::ListsController` / `Admin::Books::RankingConfigurationsController` are thin subclasses of their shared base controllers (like games); lists views are one-line shared-component wrappers, RC needs no views (inherits the shared ones). The ranking parity is a two-part fix: `Books::Book#release_year` (the generic interface the item-ranking calculator checks for) and two legacy edge cases (`yearly_award? → max`, `nil item year → max`) added to the shared `ItemRankings::Calculator`.
+
+**Tech Stack:** Rails 8, Minitest + fixtures + Mocha, ViewComponent, Turbo Frames, DaisyUI 5, Playwright.
+
+## Global Constraints
+
+- Run all commands from `web-app/`. Lint with `bundle exec standardrb` (NOT rubocop). Do not run brakeman.
+- Namespace all books code `Books::`; tests mirror the namespace (`module Admin; module Books`).
+- Controller tests assert **behavior only** (status, redirect, record deltas) — never HTML/CSS/copy.
+- Check actual fixture names before referencing; auth in integration tests via `sign_in_as(user, stub_auth: true)`; turbo/JSON requests use `as: :turbo_stream` / `as: :json`.
+- `raise_on_missing_callback_actions` is ON in dev+test — never name an action in a `before_action only: […]` list before it exists.
+- **STI subclasses have no per-model fixtures** (a `test/fixtures/books/lists.yml` would break the suite). Use the shared `test/fixtures/lists.yml` (which has `Books::List` rows) or build records in-test (the games controller tests build lists in-test — mirror that).
+- **`ItemRankings::Calculator#calculate_score_penalty` is `private`.** The parity fix is the crux of this increment and its exact per-branch values can't be isolated through the public `call` (the penalty is one input among list weight/position/bonus-pool to the WeightedListRank gem). Task 2 therefore verifies the branch parity by calling the method via `send` — a deliberate, scoped exception to "never test private methods," because it directly pins legacy behavior.
+- The date penalty only runs when `ranking_configuration.apply_list_dates_penalty?` is true (`item_rankings/calculator.rb:80`).
+- Verify with `bin/rails test` (+ `test:system` for UI) and `bundle exec standardrb`; Playwright via `yarn test:e2e`.
+- Commit messages end with `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>`. Branch `books-admin-6b` (already created off main).
+
+---
+
+### Task 1: `Books::Book#release_year`
+
+`Books::Book` exposes `first_published_year`; every other rankable item (`Music::Album`, `Games::Game`, `Movies::Movie`) exposes `release_year`, which the shared item-ranking calculator checks via `respond_to?(:release_year)`. Add the alias so books participate in the date penalty (and fix the known `MyListsController#csv_row` gap).
+
+**Files:**
+- Modify: `web-app/app/models/books/book.rb`
+- Test: `web-app/test/models/books/book_test.rb`
+
+**Interfaces:**
+- Produces: `Books::Book#release_year → Integer | nil` (returns `first_published_year`).
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `web-app/test/models/books/book_test.rb` (inside the existing `Books::BookTest`):
+
+```ruby
+  test "release_year returns first_published_year" do
+    book = ::Books::Book.new(first_published_year: 1869)
+    assert_equal 1869, book.release_year
+  end
+
+  test "release_year is nil when first_published_year is nil" do
+    assert_nil ::Books::Book.new(first_published_year: nil).release_year
+  end
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `bin/rails test test/models/books/book_test.rb -n "/release_year/"`
+Expected: FAIL — `NoMethodError: undefined method 'release_year'`.
+
+- [ ] **Step 3: Add the method**
+
+In `web-app/app/models/books/book.rb`, add inside the class body (near the other instance methods):
+
+```ruby
+  # The item-ranking calculator and CSV export use the generic `release_year`
+  # interface that every other medium exposes; books store it as first_published_year.
+  def release_year
+    first_published_year
+  end
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `bin/rails test test/models/books/book_test.rb -n "/release_year/"`
+Expected: PASS.
+
+- [ ] **Step 5: standardrb + commit**
+
+Run: `bundle exec standardrb app/models/books/book.rb test/models/books/book_test.rb` → no offenses.
+
+```bash
+git add app/models/books/book.rb test/models/books/book_test.rb
+git commit -m "$(cat <<'EOF'
+Add Books::Book#release_year delegating to first_published_year (inc 6b task 1)
+
+Matches the generic item interface the item-ranking calculator and CSV
+export expect; every other medium already exposes release_year.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 2: Legacy date-penalty parity in the shared `ItemRankings::Calculator`
+
+Reproduce the legacy TheGreatestBooks date penalty: a yearly-award list, or an item with no publication year, takes the full penalty — checked **before** the `list.year_published` guard (legacy order). This is a shared change (all domains); it's inert for music/games award lists (0 exist) and re-ranks ~1% of their nil-year items.
+
+**Files:**
+- Modify: `web-app/app/lib/item_rankings/calculator.rb` (rewrite `calculate_score_penalty`, ~line 90)
+- Test: `web-app/test/lib/item_rankings/books/calculator_test.rb` (create)
+- Test: `web-app/test/lib/item_rankings/music/albums/calculator_test.rb` (add one cross-domain assertion)
+
+**Interfaces:**
+- Consumes: `Books::Book#release_year` (Task 1); `ranking_configuration.{apply_list_dates_penalty?, max_list_dates_penalty_age, max_list_dates_penalty_percentage}`; `list.{year_published, yearly_award?}`; `list_item.listable`.
+- Produces: `ItemRankings::Calculator#calculate_score_penalty(list, list_item) → Float | nil` with legacy branch order.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `web-app/test/lib/item_rankings/books/calculator_test.rb`:
+
+```ruby
+# frozen_string_literal: true
+
+require "test_helper"
+
+module ItemRankings
+  module Books
+    class CalculatorTest < ActiveSupport::TestCase
+      setup do
+        @rc = ranking_configurations(:books_global)
+        @rc.update!(apply_list_dates_penalty: true, max_list_dates_penalty_age: 50, max_list_dates_penalty_percentage: 80)
+        @calculator = ItemRankings::Books::Calculator.new(@rc)
+      end
+
+      def penalty_for(list_year:, first_published_year:, yearly_award: false)
+        list = ::Books::List.create!(name: "L#{rand(1_000_000)}", status: :approved, year_published: list_year, yearly_award: yearly_award)
+        book = ::Books::Book.create!(title: "B#{rand(1_000_000)}", first_published_year: first_published_year)
+        list_item = list.list_items.create!(listable: book, position: 1)
+        @calculator.send(:calculate_score_penalty, list, list_item)
+      end
+
+      test "book older than the list within max_age gets a graduated penalty" do
+        # year_difference = 20; ((50-20)/50)*80/100 = 0.48
+        assert_in_delta 0.48, penalty_for(list_year: 2000, first_published_year: 1980), 0.0001
+      end
+
+      test "book newer than the list gets the max penalty" do
+        assert_in_delta 0.80, penalty_for(list_year: 2000, first_published_year: 2005), 0.0001
+      end
+
+      test "book older than max_age gets no penalty" do
+        # year_difference = 60 > 50
+        assert_nil penalty_for(list_year: 2000, first_published_year: 1940)
+      end
+
+      test "item with no publication year gets the max penalty" do
+        assert_in_delta 0.80, penalty_for(list_year: 2000, first_published_year: nil), 0.0001
+      end
+
+      test "a yearly-award list gives the item the max penalty even with a good year gap" do
+        # would otherwise be no penalty (diff 60 > 50); award forces max
+        assert_in_delta 0.80, penalty_for(list_year: 2000, first_published_year: 1940, yearly_award: true), 0.0001
+      end
+
+      test "a yearly-award list with no year_published still max-penalizes" do
+        assert_in_delta 0.80, penalty_for(list_year: nil, first_published_year: 1980, yearly_award: true), 0.0001
+      end
+
+      test "no penalty config yields nil" do
+        @rc.update!(max_list_dates_penalty_age: nil, max_list_dates_penalty_percentage: nil)
+        assert_nil penalty_for(list_year: 2000, first_published_year: 1990)
+      end
+    end
+  end
+end
+```
+
+- [ ] **Step 2: Run to verify failures**
+
+Run: `bin/rails test test/lib/item_rankings/books/calculator_test.rb`
+Expected: FAIL — with the current code, `item with no publication year` returns `nil` (line 95 skip) not `0.80`; `yearly-award` cases don't force max; `yearly-award with no year_published` returns nil at the `list.year_published` guard.
+
+- [ ] **Step 3: Rewrite `calculate_score_penalty`**
+
+Replace the method in `web-app/app/lib/item_rankings/calculator.rb` (currently ~lines 90-115) with:
+
+```ruby
+    def calculate_score_penalty(list, list_item)
+      max_age = ranking_configuration.max_list_dates_penalty_age
+      max_penalty_percentage = ranking_configuration.max_list_dates_penalty_percentage
+      return nil if max_age.nil? || max_penalty_percentage.nil?
+
+      item = list_item.listable
+      item_year = (item.respond_to?(:release_year) ? item.release_year : nil)
+
+      # Legacy parity: award lists and items with no known year take the full
+      # penalty, regardless of the list's own publication year (checked first).
+      return max_penalty_percentage / 100.0 if list.yearly_award? || item_year.nil?
+
+      return nil unless list.year_published.present?
+
+      year_difference = list.year_published - item_year
+
+      penalty = if year_difference <= 0
+        max_penalty_percentage / 100.0
+      elsif year_difference > max_age
+        nil
+      else
+        p = ((max_age - year_difference).to_f / max_age) * max_penalty_percentage
+        p / 100.0
+      end
+
+      (penalty == 0) ? nil : penalty
+    end
+```
+
+- [ ] **Step 4: Run books calculator test to verify pass**
+
+Run: `bin/rails test test/lib/item_rankings/books/calculator_test.rb`
+Expected: PASS (all 7).
+
+- [ ] **Step 5: Add the cross-domain assertion (shared behavior)**
+
+Add to `web-app/test/lib/item_rankings/music/albums/calculator_test.rb` (inside the existing test class), pinning that the nil-year rule is shared, not books-only. Reuse the RC's already-wired fixture list/album (no fragile `create!`); `update_column` bypasses validations for the nil-year setup:
+
+```ruby
+        test "an album with no release year gets the max penalty (shared date-penalty parity)" do
+          @ranking_configuration.update!(apply_list_dates_penalty: true, max_list_dates_penalty_age: 30, max_list_dates_penalty_percentage: 50)
+          list_item = @ranking_configuration.ranked_lists.first.list.list_items.first
+          list_item.list.update!(year_published: 2000)
+          list_item.listable.update_column(:release_year, nil)
+          assert_in_delta 0.50, @calculator.send(:calculate_score_penalty, list_item.list, list_item), 0.0001
+        end
+```
+
+- [ ] **Step 6: Run both calculator tests + full item_rankings suite**
+
+Run: `bin/rails test test/lib/item_rankings/`
+Expected: PASS — no regressions in the existing music/movies/games calculator tests.
+
+- [ ] **Step 7: standardrb + commit**
+
+Run: `bundle exec standardrb app/lib/item_rankings/calculator.rb test/lib/item_rankings/books/calculator_test.rb test/lib/item_rankings/music/albums/calculator_test.rb` → no offenses.
+
+```bash
+git add app/lib/item_rankings/calculator.rb test/lib/item_rankings/books/calculator_test.rb test/lib/item_rankings/music/albums/calculator_test.rb
+git commit -m "$(cat <<'EOF'
+Match legacy date penalty: yearly-award + nil-year items take max penalty (inc 6b task 2)
+
+Reproduces the legacy TheGreatestBooks calculate_score_penalty: a yearly-award
+list, or an item with no publication year, gets the full penalty, checked
+before the list.year_published guard. Shared across domains (inert for
+music/games award lists; re-ranks their nil-year items, ~1%).
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 3: Books Lists admin
+
+Thin `Admin::Books::ListsController` (games minus the wizard), `Books::List` in the `LISTS` registry, one-line views, the DomainNav "Lists" item, and the shared `ShowComponent` wizard-button guard.
+
+**Files:**
+- Modify: `web-app/config/routes.rb` (books admin namespace)
+- Create: `web-app/app/controllers/admin/books/lists_controller.rb`
+- Create: `web-app/app/views/admin/books/lists/{index,show,new,edit}.html.erb` + `{_form,_table}.html.erb`
+- Modify: `web-app/app/lib/admin/domain_routing.rb` (`LISTS`)
+- Modify: `web-app/app/lib/admin/domain_nav.rb` (`CONFIGS[:books][:items]`)
+- Modify: `web-app/app/components/admin/lists/show_component.html.erb` (wizard guard)
+- Test: `web-app/test/controllers/admin/books/lists_controller_test.rb` (create) — its `show` test asserts no "Launch Wizard" button, covering the wizard guard for books
+- Test: `web-app/test/lib/admin/domain_routing_test.rb`, `web-app/test/lib/admin/domain_nav_test.rb`
+
+**Interfaces:**
+- Produces routes: `admin_books_lists_path`, `admin_books_list_path(l)`, `new_/edit_admin_books_list_path`.
+- Produces: `Admin::Books::ListsController` (all actions inherited from `Admin::ListsBaseController`).
+
+- [ ] **Step 1: Add the route**
+
+In `web-app/config/routes.rb`, inside the books admin namespace (`module: "admin/books", as: "admin_books"`), add — **no** wizard/`items` nested routes (books list items ride the global shared `ListItemsController`):
+
+```ruby
+      resources :lists
+```
+
+Verify: `bin/rails routes -g admin_books_lists` → `admin_books_lists`, `admin_books_list`, `new_/edit_admin_books_list`.
+
+- [ ] **Step 2: Write the failing controller test**
+
+Create `web-app/test/controllers/admin/books/lists_controller_test.rb`:
+
+```ruby
+require "test_helper"
+
+module Admin
+  module Books
+    class ListsControllerTest < ActionDispatch::IntegrationTest
+      setup do
+        @admin_user = users(:admin_user)
+        @regular_user = users(:regular_user)
+        host! Rails.application.config.domains[:books]
+
+        @list = ::Books::List.create!(name: "Test Books List", status: :approved, year_published: 2020)
+      end
+
+      test "index redirects unauthenticated users" do
+        get admin_books_lists_path
+        assert_redirected_to books_root_path
+      end
+
+      test "index redirects a regular user" do
+        sign_in_as(@regular_user, stub_auth: true)
+        get admin_books_lists_path
+        assert_redirected_to books_root_path
+      end
+
+      test "index allows an admin" do
+        sign_in_as(@admin_user, stub_auth: true)
+        get admin_books_lists_path
+        assert_response :success
+      end
+
+      test "index allows a books domain editor" do
+        @regular_user.domain_roles.create!(domain: :books, permission_level: :editor)
+        sign_in_as(@regular_user, stub_auth: true)
+        get admin_books_lists_path
+        assert_response :success
+      end
+
+      test "show renders without a wizard button" do
+        sign_in_as(@admin_user, stub_auth: true)
+        get admin_books_list_path(@list)
+        assert_response :success
+        assert_no_match "Launch Wizard", response.body
+      end
+
+      test "creates a list for an admin" do
+        sign_in_as(@admin_user, stub_auth: true)
+        assert_difference("::Books::List.count", 1) do
+          post admin_books_lists_path, params: {books_list: {name: "New List", status: "unapproved"}}
+        end
+        assert_redirected_to admin_books_list_path(::Books::List.order(:id).last)
+      end
+
+      test "updates a list for an admin" do
+        sign_in_as(@admin_user, stub_auth: true)
+        patch admin_books_list_path(@list), params: {books_list: {name: "Renamed"}}
+        @list.reload
+        assert_redirected_to admin_books_list_path(@list)
+        assert_equal "Renamed", @list.name
+      end
+
+      test "destroys a list for an admin" do
+        sign_in_as(@admin_user, stub_auth: true)
+        assert_difference("::Books::List.count", -1) do
+          delete admin_books_list_path(@list)
+        end
+        assert_redirected_to admin_books_lists_path
+      end
+    end
+  end
+end
+```
+
+- [ ] **Step 3: Run to verify failure**
+
+Run: `bin/rails test test/controllers/admin/books/lists_controller_test.rb`
+Expected: FAIL — `Admin::Books::ListsController` uninitialized.
+
+- [ ] **Step 4: Create the controller**
+
+Create `web-app/app/controllers/admin/books/lists_controller.rb`:
+
+```ruby
+class Admin::Books::ListsController < Admin::ListsBaseController
+  include Admin::DomainScopedAuth
+
+  private
+
+  def policy_class = ::Books::ListPolicy
+
+  def item_label = "Book"
+
+  protected
+
+  def list_class = ::Books::List
+
+  def lists_path = admin_books_lists_path
+
+  def list_path(list) = admin_books_list_path(list)
+
+  def new_list_path = new_admin_books_list_path
+
+  def edit_list_path(list) = edit_admin_books_list_path(list)
+
+  def param_key = :books_list
+
+  def items_count_name = "books_count"
+
+  def listable_includes = [:authors]
+
+  def wizard_path(_list) = nil
+end
+```
+
+- [ ] **Step 5: Create the views (one-line component wrappers, mirroring games)**
+
+`web-app/app/views/admin/books/lists/index.html.erb`:
+```erb
+<% content_for :title, "Book Lists" %>
+<%= render Admin::Lists::IndexComponent.new(lists: @lists, pagy: @pagy, domain_config: domain_config, selected_status: @selected_status, search_query: @search_query) %>
+```
+`_table.html.erb`:
+```erb
+<%= render Admin::Lists::TableComponent.new(lists: lists, pagy: pagy, domain_config: domain_config, search_query: search_query) %>
+```
+`show.html.erb`:
+```erb
+<% content_for :title, @list.name %>
+<%= render Admin::Lists::ShowComponent.new(list: @list, domain_config: domain_config) %>
+```
+`new.html.erb`:
+```erb
+<% content_for :title, "New Book List" %>
+<%= render Admin::Lists::NewComponent.new(list: @list, domain_config: domain_config) %>
+```
+`edit.html.erb`:
+```erb
+<% content_for :title, "Edit #{@list.name}" %>
+<%= render Admin::Lists::EditComponent.new(list: @list, domain_config: domain_config) %>
+```
+`_form.html.erb`:
+```erb
+<%= render Admin::Lists::FormComponent.new(list: @list, domain_config: domain_config) %>
+```
+
+- [ ] **Step 6: Guard the shared wizard button**
+
+In `web-app/app/components/admin/lists/show_component.html.erb`, wrap the "Launch Wizard" `link_to` (currently `<%= link_to domain_config[:wizard_path_proc].call(list), class: "btn btn-secondary" do %> … <% end %>`) in a presence guard:
+
+```erb
+      <% wizard_link = domain_config[:wizard_path_proc].call(list) %>
+      <% if wizard_link.present? %>
+        <%= link_to wizard_link, class: "btn btn-secondary" do %>
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+            <path fill-rule="evenodd" d="M5 2a1 1 0 011 1v1h1a1 1 0 010 2H6v1a1 1 0 01-2 0V6H3a1 1 0 010-2h1V3a1 1 0 011-1zm0 10a1 1 0 011 1v1h1a1 1 0 110 2H6v1a1 1 0 11-2 0v-1H3a1 1 0 110-2h1v-1a1 1 0 011-1zM12 2a1 1 0 01.967.744L14.146 7.2 17.5 9.134a1 1 0 010 1.732l-3.354 1.935-1.18 4.455a1 1 0 01-1.933 0L9.854 12.8 6.5 10.866a1 1 0 010-1.732l3.354-1.935 1.18-4.455A1 1 0 0112 2z" clip-rule="evenodd" />
+          </svg>
+          <span>Launch Wizard</span>
+          <% if list.wizard_state.present? && list.wizard_state["completed_at"].blank? %>
+            <span class="badge badge-warning badge-sm">In Progress</span>
+          <% end %>
+        <% end %>
+      <% end %>
+```
+
+- [ ] **Step 7: Register the list + nav item**
+
+In `web-app/app/lib/admin/domain_routing.rb`, add to `LISTS`:
+```ruby
+      "Books::List" => {
+        domain: :books,
+        listable_type: "Books::Book",
+        item_label: "Book",
+        path: ->(l) { URL_HELPERS.admin_books_list_path(l) },
+        autocomplete_path: -> { URL_HELPERS.search_admin_books_books_path }
+      },
+```
+
+In `web-app/app/lib/admin/domain_nav.rb`, append to `CONFIGS[:books][:items]` (after the Categories item):
+```ruby
+          {label: "Lists", icon: :list, path: -> { URL_HELPERS.admin_books_lists_path }},
+```
+
+- [ ] **Step 8: Registry + nav + component tests**
+
+Add to `web-app/test/lib/admin/domain_routing_test.rb`:
+```ruby
+    test "LISTS resolves a books list to the books book typeahead" do
+      config = Admin::DomainRouting.list_config(::Books::List.new)
+      assert_equal :books, config[:domain]
+      assert_equal "Book", config[:item_label]
+      assert_equal Rails.application.routes.url_helpers.search_admin_books_books_path, config[:autocomplete_path]
+    end
+```
+
+Add to `web-app/test/lib/admin/domain_nav_test.rb`:
+```ruby
+    test "the books nav includes a Lists item" do
+      item = Admin::DomainNav.config_for(:books)[:items].find { |i| i[:label] == "Lists" }
+      assert item, "books nav is missing a Lists item"
+      assert_equal "/admin/lists", item[:path]
+    end
+```
+
+(The wizard guard is verified for books by the controller `show` test above — `assert_no_match "Launch Wizard"`. The games/music direction, where the button still renders, is covered by their existing lists show tests, which render the same shared component with a real `wizard_path`.)
+
+- [ ] **Step 9: Run the lists tests**
+
+Run: `bin/rails test test/controllers/admin/books/lists_controller_test.rb test/lib/admin/domain_routing_test.rb test/lib/admin/domain_nav_test.rb test/controllers/admin/games/lists_controller_test.rb`
+Expected: PASS — including the games lists show test (confirms the wizard-guard change didn't hide the button where a real path exists).
+
+- [ ] **Step 10: standardrb + commit**
+
+Run standardrb on the touched Ruby files → no offenses.
+
+```bash
+git add config/routes.rb app/controllers/admin/books/lists_controller.rb app/views/admin/books/lists app/lib/admin/domain_routing.rb app/lib/admin/domain_nav.rb app/components/admin/lists/show_component.html.erb test/controllers/admin/books/lists_controller_test.rb test/lib/admin/domain_routing_test.rb test/lib/admin/domain_nav_test.rb
+git commit -m "$(cat <<'EOF'
+Add books lists admin, no wizard (inc 6b task 3)
+
+Thin Admin::Books::ListsController + one-line views + Books::List in the
+LISTS registry + DomainNav Lists item. Books has no wizard: wizard_path
+returns nil and the shared Lists::ShowComponent guards the Launch Wizard
+button on the path being present.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 4: Books Ranking Configurations admin
+
+Thin `Admin::Books::RankingConfigurationsController` (no new views — inherits the shared RC views), the registry `path:` that gates books-domain auth for the shared ranked-lists/penalty views, and the two denial-test flips.
+
+**Files:**
+- Modify: `web-app/config/routes.rb` (books admin namespace)
+- Create: `web-app/app/controllers/admin/books/ranking_configurations_controller.rb`
+- Modify: `web-app/app/lib/admin/domain_routing.rb` (`RANKING_CONFIGURATIONS`)
+- Modify: `web-app/app/lib/admin/domain_nav.rb` (`CONFIGS[:books][:items]`)
+- Test: `web-app/test/controllers/admin/books/ranking_configurations_controller_test.rb` (create)
+- Test: `web-app/test/controllers/admin/ranked_lists_controller_test.rb`, `web-app/test/controllers/admin/penalty_applications_controller_test.rb` (flip denial tests)
+- Test: `web-app/test/lib/admin/domain_routing_test.rb`, `web-app/test/lib/admin/domain_nav_test.rb`
+
+**Interfaces:**
+- Produces routes: `admin_books_ranking_configurations_path`, `admin_books_ranking_configuration_path(rc)`, `new_/edit_admin_books_ranking_configuration_path`, `execute_action_admin_books_ranking_configuration_path(rc)`, `index_action_admin_books_ranking_configurations_path`.
+
+- [ ] **Step 1: Add the route**
+
+In the books admin namespace of `web-app/config/routes.rb`:
+```ruby
+      resources :ranking_configurations do
+        member { post :execute_action }
+        collection { post :index_action }
+      end
+```
+Verify: `bin/rails routes -g admin_books_ranking`.
+
+- [ ] **Step 2: Write the failing controller test**
+
+Create `web-app/test/controllers/admin/books/ranking_configurations_controller_test.rb`:
+
+```ruby
+require "test_helper"
+
+module Admin
+  module Books
+    class RankingConfigurationsControllerTest < ActionDispatch::IntegrationTest
+      setup do
+        @admin_user = users(:admin_user)
+        @regular_user = users(:regular_user)
+        @rc = ranking_configurations(:books_global)
+        host! Rails.application.config.domains[:books]
+      end
+
+      test "index redirects unauthenticated users" do
+        get admin_books_ranking_configurations_path
+        assert_redirected_to books_root_path
+      end
+
+      test "index redirects a regular user" do
+        sign_in_as(@regular_user, stub_auth: true)
+        get admin_books_ranking_configurations_path
+        assert_redirected_to books_root_path
+      end
+
+      test "index allows an admin" do
+        sign_in_as(@admin_user, stub_auth: true)
+        get admin_books_ranking_configurations_path
+        assert_response :success
+      end
+
+      test "index allows a books domain viewer to read" do
+        @regular_user.domain_roles.create!(domain: :books, permission_level: :viewer)
+        sign_in_as(@regular_user, stub_auth: true)
+        get admin_books_ranking_configurations_path
+        assert_response :success
+      end
+
+      test "show for an admin" do
+        sign_in_as(@admin_user, stub_auth: true)
+        get admin_books_ranking_configuration_path(@rc)
+        assert_response :success
+      end
+
+      test "index tolerates a sort-injection attempt" do
+        sign_in_as(@admin_user, stub_auth: true)
+        assert_nothing_raised do
+          get admin_books_ranking_configurations_path(sort: "'; DROP TABLE ranking_configurations; --")
+        end
+        assert_response :success
+      end
+
+      test "creates a ranking configuration for an admin" do
+        sign_in_as(@admin_user, stub_auth: true)
+        assert_difference("::Books::RankingConfiguration.count", 1) do
+          post admin_books_ranking_configurations_path, params: {ranking_configuration: {name: "New Books RC"}}
+        end
+        assert_redirected_to admin_books_ranking_configuration_path(::Books::RankingConfiguration.order(:id).last)
+      end
+
+      test "does not allow a books editor to create (manage required)" do
+        @regular_user.domain_roles.create!(domain: :books, permission_level: :editor)
+        sign_in_as(@regular_user, stub_auth: true)
+        assert_no_difference("::Books::RankingConfiguration.count") do
+          post admin_books_ranking_configurations_path, params: {ranking_configuration: {name: "Nope"}}
+        end
+      end
+    end
+  end
+end
+```
+
+(The base controller uses `params.require(:ranking_configuration)` — a generic key, no `param_key` hook. `Books::RankingConfiguration.new(name: "x")` is valid on its own: `algorithm_version`/`exponent`/`bonus_pool_percentage`/`min_list_weight` all carry DB defaults, so `name` alone creates successfully.)
+
+- [ ] **Step 3: Run to verify failure**
+
+Run: `bin/rails test test/controllers/admin/books/ranking_configurations_controller_test.rb`
+Expected: FAIL — controller uninitialized.
+
+- [ ] **Step 4: Create the controller**
+
+Create `web-app/app/controllers/admin/books/ranking_configurations_controller.rb`:
+
+```ruby
+module Admin
+  module Books
+    class RankingConfigurationsController < Admin::RankingConfigurationsController
+      include Admin::DomainScopedAuth
+
+      private
+
+      def policy_class = ::Books::RankingConfigurationPolicy
+
+      def domain_name = "books"
+
+      def ranking_configuration_class = ::Books::RankingConfiguration
+
+      def ranking_configurations_path(**opts) = admin_books_ranking_configurations_path(**opts)
+
+      def ranking_configuration_path(config, **opts) = admin_books_ranking_configuration_path(config, **opts)
+
+      def new_ranking_configuration_path = new_admin_books_ranking_configuration_path
+
+      def edit_ranking_configuration_path(config) = edit_admin_books_ranking_configuration_path(config)
+
+      def execute_action_ranking_configuration_path(config, **opts) = execute_action_admin_books_ranking_configuration_path(config, **opts)
+
+      def index_action_ranking_configurations_path(**opts) = index_action_admin_books_ranking_configurations_path(**opts)
+    end
+  end
+end
+```
+
+- [ ] **Step 5: Register the RC path + nav item**
+
+In `web-app/app/lib/admin/domain_routing.rb`, change the `"Books::RankingConfiguration"` entry's `path`:
+```ruby
+      "Books::RankingConfiguration" => {
+        domain: :books,
+        list_type: "Books::List",
+        ranked_item_includes: nil,
+        path: ->(rc) { URL_HELPERS.admin_books_ranking_configuration_path(rc) }
+      },
+```
+
+In `web-app/app/lib/admin/domain_nav.rb`, append to `CONFIGS[:books][:items]`:
+```ruby
+          {label: "Rankings", icon: :chart, path: -> { URL_HELPERS.admin_books_ranking_configurations_path }}
+```
+
+- [ ] **Step 6: Flip the two denial tests (auth landmine)**
+
+In `web-app/test/controllers/admin/ranked_lists_controller_test.rb`, the test at ~line 183 ("should deny access to a books ranking configuration for a user with only a books domain role") now grants **read** access — rewrite it to mirror the games test directly below it:
+
+```ruby
+    test "should allow access to a books ranking configuration for a user with only a books domain role" do
+      books_config = ranking_configurations(:books_global)
+      @regular_user.domain_roles.create!(domain: :books, permission_level: :viewer)
+      sign_in_as(@regular_user, stub_auth: true)
+
+      get admin_ranking_configuration_ranked_lists_path(books_config)
+
+      assert_response :success
+    end
+```
+
+In `web-app/test/controllers/admin/penalty_applications_controller_test.rb`, the equivalent test at ~line 226 — same flip (rename to "should allow…", change the final assertion to `assert_response :success`; keep the `get admin_ranking_configuration_penalty_applications_path(books_config)` request).
+
+- [ ] **Step 7: Registry + nav assertions**
+
+Add to `web-app/test/lib/admin/domain_routing_test.rb`:
+```ruby
+    test "RANKING_CONFIGURATIONS resolves a books RC path" do
+      rc = ranking_configurations(:books_global)
+      assert_equal Rails.application.routes.url_helpers.admin_books_ranking_configuration_path(rc),
+        Admin::DomainRouting.ranking_configuration_config(rc)[:path]
+    end
+```
+
+Add to `web-app/test/lib/admin/domain_nav_test.rb`:
+```ruby
+    test "the books nav includes a Rankings item" do
+      item = Admin::DomainNav.config_for(:books)[:items].find { |i| i[:label] == "Rankings" }
+      assert item, "books nav is missing a Rankings item"
+      assert_equal "/admin/ranking_configurations", item[:path]
+    end
+```
+
+- [ ] **Step 8: Run the RC + affected shared tests**
+
+Run: `bin/rails test test/controllers/admin/books/ranking_configurations_controller_test.rb test/controllers/admin/ranked_lists_controller_test.rb test/controllers/admin/penalty_applications_controller_test.rb test/lib/admin/domain_routing_test.rb test/lib/admin/domain_nav_test.rb`
+Expected: PASS — including the two flipped tests now asserting books-domain read access.
+
+- [ ] **Step 9: standardrb + commit**
+
+Run standardrb on the touched Ruby files → no offenses.
+
+```bash
+git add config/routes.rb app/controllers/admin/books/ranking_configurations_controller.rb app/lib/admin/domain_routing.rb app/lib/admin/domain_nav.rb test/controllers/admin/books/ranking_configurations_controller_test.rb test/controllers/admin/ranked_lists_controller_test.rb test/controllers/admin/penalty_applications_controller_test.rb test/lib/admin/domain_routing_test.rb test/lib/admin/domain_nav_test.rb
+git commit -m "$(cat <<'EOF'
+Add books ranking-configurations admin + registry path (inc 6b task 4)
+
+Thin controller (inherits the shared RC views) + DomainNav Rankings item.
+Registering Books::RankingConfiguration's path gates books-domain auth for
+the shared ranked-lists/penalty views; the two books-denial tests flip to
+allowed (read) by design.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 5: Playwright smoke specs
+
+Mirror `e2e/tests/books/admin/authors.spec.ts` (the `books-admin` project, stored auth state). Books admin list items ride the shared typeahead; keep the specs to index + create + one show/typeahead interaction.
+
+**Files:**
+- Create: `web-app/e2e/tests/books/admin/lists.spec.ts`
+- Create: `web-app/e2e/tests/books/admin/ranking-configurations.spec.ts`
+
+- [ ] **Step 1: Write the lists spec**
+
+Create `web-app/e2e/tests/books/admin/lists.spec.ts`:
+
+```ts
+import { test, expect } from "@playwright/test";
+
+test.describe("Books admin — lists", () => {
+  test("lists index and links to New List", async ({ page }) => {
+    await page.goto("/admin/lists");
+    await expect(page.getByRole("heading", { name: "Book Lists", level: 1 })).toBeVisible();
+  });
+
+  test("creates a list and shows it without a wizard button", async ({ page }) => {
+    const name = `E2E List ${Date.now()}`;
+    await page.goto("/admin/lists/new");
+    await page.locator('input[name="books_list[name]"]').fill(name);
+    await page.getByRole("button", { name: "Create Book List" }).click();
+    await expect(page.getByRole("heading", { name, level: 1 })).toBeVisible();
+    await expect(page.getByRole("link", { name: "Launch Wizard" })).toHaveCount(0);
+  });
+});
+```
+(Index `<h1>` is `"#{item_label} Lists"` → "Book Lists"; the form submit is `"Create #{item_label} List"` → "Create Book List", from `Admin::Lists::IndexComponent` / `FormComponent`.)
+
+- [ ] **Step 2: Write the ranking-configurations spec**
+
+Create `web-app/e2e/tests/books/admin/ranking-configurations.spec.ts`:
+
+```ts
+import { test, expect } from "@playwright/test";
+
+test.describe("Books admin — ranking configurations", () => {
+  test("lists ranking configurations", async ({ page }) => {
+    await page.goto("/admin/ranking_configurations");
+    await expect(page.getByRole("heading", { level: 1 }).first()).toBeVisible();
+  });
+
+  test("creates a ranking configuration", async ({ page }) => {
+    const name = `E2E RC ${Date.now()}`;
+    await page.goto("/admin/ranking_configurations/new");
+    await page.locator('input[name="ranking_configuration[name]"]').fill(name);
+    await page.getByRole("button", { name: /Create|Save/ }).click();
+    await expect(page.getByText(name)).toBeVisible();
+  });
+});
+```
+(Verify the shared RC index/new/form headings + submit label and the `name` input selector against `app/views/admin/ranking_configurations/*`; adjust selectors to the exact rendered markup.)
+
+- [ ] **Step 3: Validate they register**
+
+Run: `yarn playwright test --list e2e/tests/books/admin/lists.spec.ts e2e/tests/books/admin/ranking-configurations.spec.ts` → the specs list under `[books-admin]`.
+
+- [ ] **Step 4: Run them (dev server up)**
+
+Run: `yarn test:e2e e2e/tests/books/admin/lists.spec.ts e2e/tests/books/admin/ranking-configurations.spec.ts`
+Expected: all pass. If the dev server is unavailable, the specs still register; note it and run when the server is up (`bin/dev`, `bin/rails e2e:admin` if the role lapsed). Fix any selector that fails against the real rendered markup (do not weaken assertions to force a pass).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add e2e/tests/books/admin/lists.spec.ts e2e/tests/books/admin/ranking-configurations.spec.ts
+git commit -m "$(cat <<'EOF'
+Add books lists + ranking-configurations Playwright smoke specs (inc 6b task 5)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Final verification
+
+- [ ] `bin/rails test` — full suite green (baseline 4805/0 after 6a; expect that plus the new tests).
+- [ ] `bundle exec standardrb` — no offenses.
+- [ ] `yarn test:e2e e2e/tests/books/admin/lists.spec.ts e2e/tests/books/admin/ranking-configurations.spec.ts` — pass (dev server up).
+- [ ] Confirm the only edits to existing music/games tests are the two deliberate denial-test flips (Task 4) and the one shared-calculator assertion (Task 2). Any other change to an existing assertion is a red flag — stop and investigate.
+- [ ] Sanity-check the reframing held: `grep -rn "num_years_covered" app/` shows no books RC applies it; `calculate_books_year_range` was left untouched.
+
+## Notes / carried context
+
+- **Deferred follow-up PR (not in 6b):** gate the shared `ranked_lists` / `penalty_applications` / `list_items` / `list_penalties` mutations on domain write (the 6a `require_domain_write!` pattern), closing the pre-existing viewer-write gap that 6b's RC-path registration newly exposes for books (6b grants **read** only; the denial-test flips are GET requests).
+- RC create requires **manage** (admin), not editor — `Books::RankingConfigurationPolicy` (via `ApplicationPolicy#create? → manage?`-gated in the RC controller). The editor-denied create test in Task 4 pins this.

--- a/docs/superpowers/specs/2026-07-22-books-admin-6b-lists-rankings-design.md
+++ b/docs/superpowers/specs/2026-07-22-books-admin-6b-lists-rankings-design.md
@@ -182,8 +182,9 @@ RC's date penalty is a silent no-op, and the new books rankings do not match the
 1. **`Books::Book#release_year`** delegating to `first_published_year` (matches the generic item
    interface every other medium already satisfies; also fixes the known `MyListsController#csv_row` gap
    that calls `listable.release_year`).
-2. Two legacy behaviors into the **shared** `ItemRankings::Calculator#calculate_score_penalty`
-   (general rules — 6b-6):
+2. Extract the pure penalty math into a public, unit-tested `ItemRankings::DatePenalty` PORO (so it's
+   tested directly, not via the private `calculate_score_penalty`, which becomes a thin adapter), and add
+   the two legacy behaviors as **general** rules (6b-6):
    - `list.yearly_award?` → max penalty (`max_penalty_percentage / 100.0`). Live for books' 50 award
      lists; inert for music/games (0 award lists today).
    - `item.release_year` nil (when the RC applies the date penalty with age/pct set) → max penalty

--- a/docs/superpowers/specs/2026-07-22-books-admin-6b-lists-rankings-design.md
+++ b/docs/superpowers/specs/2026-07-22-books-admin-6b-lists-rankings-design.md
@@ -1,0 +1,237 @@
+# Books admin — increment 6b: Lists + Ranking Configurations + legacy date-penalty parity
+
+**Status:** design approved 2026-07-22, pending plan.
+**Parent design:** `docs/superpowers/specs/2026-07-13-books-admin-ui-design.md` (umbrella; increment 6,
+"Categories, Lists, Ranking configurations"; decision D8).
+**Predecessors:** 6a (categories + shared-controller domain-auth fix — PR #174, merged `a89fd73`).
+**Split:** increment 6 shipped as 6a (categories) + **6b (this doc)**. One PR (owner call, 2026-07-22).
+
+## Goal
+
+The books admin's Lists and Ranking-Configuration surfaces at `new.thegreatestbooks.org/admin`, plus
+the fix that makes the new books rankings actually reproduce the **legacy** TheGreatestBooks ranking
+algorithm. `Books::List` (1,030 rows) and `Books::RankingConfiguration` (4 rows) are already migrated;
+this is their admin surface, and the point at which "Refresh Rankings" must produce legacy-correct
+output.
+
+## Scope
+
+**In:**
+- **`Books::List` CRUD** — thin subclass of `Admin::ListsBaseController`, list items managed through the
+  existing shared `Admin::ListItemsController` + a books typeahead. **No wizard** (no importer / external
+  API — design D1).
+- **`Books::RankingConfiguration` CRUD** — thin subclass of `Admin::RankingConfigurationsController`;
+  ranked-lists / penalty-applications / ranked-items come free once the registry knows books' RC path.
+- **Legacy date-penalty parity (revised D8)** — `Books::Book#release_year` + two legacy behaviors in the
+  shared item-ranking calculator, so the books date penalty runs like the old site. See Part 3 — this
+  **replaces** the umbrella's `calculate_books_year_range` fix, which turns out to be moot for books.
+- `DomainNav` "Lists" + "Rankings" items, `DomainRouting` `LISTS` + `RANKING_CONFIGURATIONS` entries,
+  Minitest coverage, and Playwright smoke specs.
+
+**Out (deferred / not applicable):**
+- **`calculate_books_year_range` (umbrella D8)** — dropped. It belongs to the per-list *temporal-coverage*
+  penalty (`dynamic_type: :num_years_covered`), which **no books RC applies**, so the stub is dead code
+  for books and the legacy app has no year-range concept at all (Part 3). Left untouched.
+- **Viewer-can-write hardening** of the shared `ranked_lists` / `penalty_applications` / `list_items` /
+  `list_penalties` controllers — its own follow-up PR (owner call). 6b's registry-path addition grants
+  books domain users **read** access to these (the denial-test flips below are reads); it does **not**
+  introduce any new viewer-*write* path beyond the pre-existing cross-domain gap. Tracked separately.
+- No list wizard, no external books API/importer (D1). Inc 7 (full Playwright suite) stays separate.
+
+## Decisions
+
+| # | Decision | Rationale |
+|---|---|---|
+| 6b-1 | One PR (lists + RC + date-penalty parity). | Coupled: the RC admin's "Refresh Rankings" is only correct once the date-penalty parity fix lands. Owner call. |
+| 6b-2 | Books lists have **no wizard**; guard the shared `Admin::Lists::ShowComponent` "Launch Wizard" button on the wizard path being present, and books' `wizard_path` returns `nil`. | The base controller *requires* a `wizard_path` hook, and the ShowComponent renders the button unconditionally today. Making the button conditional is a one-line, behavior-neutral improvement (music/games return real paths) — cleaner than a bespoke books show view. |
+| 6b-3 | Books RC needs **zero** new views. | The base `RankingConfigurationsController` renders the shared `app/views/admin/ranking_configurations/*`, resolved by controller inheritance; games' RC subclass has no own views either. |
+| 6b-4 | Register `Books::RankingConfiguration`'s `path:` — accept that this flips the shared `ranked_lists` / `penalty_applications` books-denial tests to *allowed*. | The `path:` is load-bearing for auth (`domain_with_ranking_configuration_admin_for`). The flips are **read** access for books domain users and are the intended effect (inc-3 landmine). |
+| 6b-5 | **Drop** the `calculate_books_year_range` fix; do the `release_year` + legacy-parity fix instead. | Investigation (below) shows the year-range function is never called for books, and the real gap is that `Books::Book` lacks `release_year`, silently disabling the legacy recency penalty the primary RC is configured to apply. |
+| 6b-6 | The two legacy edge cases (nil publication year → max penalty; yearly-award list → max penalty) go in the **shared** `ItemRankings::Calculator`, not a books override. | Owner: these are general ranking rules, "just not implemented yet" for music/games. `yearly_award` is inert there (0 award lists); the nil-year change re-ranks ~1% of music/games items — an accepted correctness fix, folded into 6b. |
+
+## Part 1 — Books Lists
+
+### Model (exists — no schema change)
+`Books::List < List` (STI on `lists`): `name`, `status` enum, `year_published` (765/1,030 populated),
+`yearly_award` (boolean; **50 books lists are award lists**), `wizard_state` (jsonb, unused for books),
+`simplified_content`, etc. `list_items` are polymorphic (`listable: Books::Book`), all 65,252 linked.
+
+### Controller
+`Admin::Books::ListsController < Admin::ListsBaseController` + `include Admin::DomainScopedAuth`, mirroring
+`Admin::Games::ListsController` **minus the wizard**:
+
+```ruby
+def policy_class   = ::Books::ListPolicy
+def item_label     = "Book"
+def list_class     = ::Books::List
+def lists_path     = admin_books_lists_path
+def list_path(l)   = admin_books_list_path(l)
+def new_list_path  = new_admin_books_list_path
+def edit_list_path(l) = edit_admin_books_list_path(l)
+def param_key      = :books_list
+def items_count_name = "books_count"
+def listable_includes = [:authors]
+def wizard_path(_list) = nil   # books has no wizard
+```
+
+### Shared-component change (the "no wizard" mechanism)
+`app/components/admin/lists/show_component.html.erb:31` renders `link_to wizard_path_proc.call(list)`
+unconditionally. Compute it into a local and guard:
+
+```erb
+<% wizard_link = domain_config[:wizard_path_proc].call(list) %>
+<% if wizard_link.present? %>
+  <%= link_to wizard_link, class: "btn btn-secondary" do %> … Launch Wizard … <% end %>
+<% end %>
+```
+
+Behavior-neutral for music/games (real paths); books (nil) renders no button. This is the only touch to
+shared list rendering.
+
+### Routes / registry / views / nav
+- Books admin namespace: `resources :lists` — **no** wizard/`items` nested routes (unlike games). List
+  items ride the global shared `Admin::ListItemsController` (its `list.type.split("::")` auth already
+  resolves `Books::List` → `"books"`).
+- `DomainRouting::LISTS["Books::List"] = {domain: :books, listable_type: "Books::Book", item_label:
+  "Book", path: ->(l) { admin_books_list_path(l) }, autocomplete_path: -> { search_admin_books_books_path }}`
+  — powers the list show-page "add item" book typeahead.
+- Views: one-line wrappers around the shared `Admin::Lists::*Component` (mirror `admin/games/lists/`).
+- `DomainNav CONFIGS[:books][:items]` += `{label: "Lists", icon: :list, path: -> { admin_books_lists_path }}`.
+- `Books::ListPolicy` already exists.
+
+## Part 2 — Books Ranking Configurations
+
+### Controller
+`Admin::Books::RankingConfigurationsController < Admin::RankingConfigurationsController` +
+`include Admin::DomainScopedAuth`, mirroring `Admin::Games::RankingConfigurationsController`:
+
+```ruby
+def policy_class = ::Books::RankingConfigurationPolicy
+def domain_name  = "books"
+def ranking_configuration_class = ::Books::RankingConfiguration
+def ranking_configurations_path(**o) = admin_books_ranking_configurations_path(**o)
+def ranking_configuration_path(rc, **o) = admin_books_ranking_configuration_path(rc, **o)
+def new_ranking_configuration_path = new_admin_books_ranking_configuration_path
+def edit_ranking_configuration_path(rc) = edit_admin_books_ranking_configuration_path(rc)
+def execute_action_ranking_configuration_path(rc, **o) = execute_action_admin_books_ranking_configuration_path(rc, **o)
+def index_action_ranking_configurations_path(**o) = index_action_admin_books_ranking_configurations_path(**o)
+```
+
+**No new views** — inherits the shared `app/views/admin/ranking_configurations/*`.
+
+### Routes / registry / auth landmine / nav
+- Books admin namespace:
+  ```ruby
+  resources :ranking_configurations do
+    member { post :execute_action }
+    collection { post :index_action }
+  end
+  ```
+- `DomainRouting::RANKING_CONFIGURATIONS["Books::RankingConfiguration"][:path]` →
+  `->(rc) { admin_books_ranking_configuration_path(rc) }` (currently `nil`).
+- **Auth landmine (load-bearing):** the `path:` is what `Admin::DomainScopedAuth
+  #domain_with_ranking_configuration_admin_for` keys on. Setting it makes books domain users resolve
+  `:books` and gain access to the shared globally-routed `RankedLists` / `RankedItems` /
+  `PenaltyApplications` controllers for books RCs. This **flips two existing denial tests** from redirect
+  to success — update them, don't fight them:
+  - `test/controllers/admin/ranked_lists_controller_test.rb:183` ("should deny access to a books ranking
+    configuration for a user with only a books domain role" → now allowed; a books viewer may **read**).
+  - the equivalent books-denial test in `penalty_applications_controller_test.rb`.
+- `DomainNav CONFIGS[:books][:items]` += `{label: "Rankings", icon: :chart, path: -> { admin_books_ranking_configurations_path }}`.
+- `Books::RankingConfigurationPolicy` already exists (gates create/update/destroy on `manage?`).
+- "Refresh Rankings" / "Bulk Calculate Weights" run via the existing `ItemRankings::Books::Calculator`
+  and `RankingConfiguration#calculator_service` — **no new code** — but Refresh's per-item date penalty
+  is wrong until Part 3.
+
+## Part 3 — Legacy date-penalty parity (the real "D8")
+
+### What the legacy app does (`the-greatest-books/admin`)
+The legacy books ranking has **no year-range / temporal-coverage penalty**. Its date penalty
+(`app/lib/rankings/calculator.rb#calculate_score_penalty`) is a **per-book recency** penalty:
+
+```
+return max_pct/100.0  if list.yearly_award? || book.first_year_published.nil?
+return nil            unless list.year_published && book.first_year_published
+year_difference = list.year_published - book.first_year_published
+  year_difference <= 0        → max_pct/100.0        # book newer than the list → full penalty
+  year_difference > max_age   → nil                   # old enough → no penalty
+  else                        → ((max_age - year_difference)/max_age) * max_pct / 100.0
+```
+
+bounded by the RC's `max_age_for_penalty` and `max_penalty_percentage`, toggled by
+`apply_list_dates_penalty`.
+
+### What the new app does (verified)
+- The new `Rankings::WeightCalculatorV1#calculate_books_year_range` belongs to the per-list
+  *temporal-coverage* penalty (`dynamic_type: :num_years_covered`). **None of the 4 books RCs apply it**
+  (their dynamic penalties are voter-count/bias only), so it is **never called for books**. Dead code.
+- The legacy recency penalty **is** ported — the shared `ItemRankings::Calculator#calculate_score_penalty`
+  (`calculator.rb:90`) has the identical graduated formula, gated on `apply_list_dates_penalty?` +
+  `max_list_dates_penalty_age` / `max_list_dates_penalty_percentage`.
+- The **primary** books RC (#8 "May 2026") carries these, migrated from legacy:
+  `apply_list_dates_penalty=true, max_list_dates_penalty_age=50, max_list_dates_penalty_percentage=80`.
+  So the intent is clearly to run the legacy recency penalty. (Every domain's primary RC has the toggle on.)
+
+### The bug
+`calculator.rb:95` guards with `item.respond_to?(:release_year) && item.release_year.present?`.
+`Music::Album`, `Games::Game`, and `Movies::Movie` all expose `release_year`; **`Books::Book` does not**
+(it has `first_published_year`). So for **every book**, the penalty returns `nil` there — the primary
+RC's date penalty is a silent no-op, and the new books rankings do not match the old site.
+
+### The fix
+1. **`Books::Book#release_year`** delegating to `first_published_year` (matches the generic item
+   interface every other medium already satisfies; also fixes the known `MyListsController#csv_row` gap
+   that calls `listable.release_year`).
+2. Two legacy behaviors into the **shared** `ItemRankings::Calculator#calculate_score_penalty`
+   (general rules — 6b-6):
+   - `list.yearly_award?` → max penalty (`max_penalty_percentage / 100.0`). Live for books' 50 award
+     lists; inert for music/games (0 award lists today).
+   - `item.release_year` nil (when the RC applies the date penalty with age/pct set) → max penalty
+     instead of the current skip. Re-ranks ~1% of music/games items (40 albums, 1,043 songs, 12 games)
+     and 27% of books (33,948) — accepted correctness/parity change.
+   **Order matters for parity:** legacy checks `yearly_award? || book-year-nil → max` *before* the
+   `list.year_published` guard, so a yearly-award list with no `year_published` still max-penalizes. The
+   new calc's `return nil unless list.year_published.present?` currently runs first — the two max-penalty
+   checks must move ahead of it (and ahead of the `max_age`/`max_pct` presence guard, which they depend
+   on), matching the legacy branch order: `yearly_award || nil-item-year → max`, then
+   `nil list-year → none`, then `year_diff ≤ 0 → max`, `> max_age → none`, else graduated.
+3. **Do not** touch `calculate_books_year_range` (moot for books).
+
+## Testing
+
+- **`admin/books/lists_controller_test.rb`** — index/CRUD/auth (books writer allowed, books viewer read,
+  regular redirected); the show page renders with **no** Launch Wizard button.
+- **`admin/books/ranking_configurations_controller_test.rb`** — index/CRUD/auth; `execute_action`
+  (member) and `index_action` (collection) dispatch.
+- **Registry units** — `LISTS["Books::List"]` resolves + `list_config` returns the books book typeahead;
+  `RANKING_CONFIGURATIONS["Books::RankingConfiguration"][:path]` resolves.
+- **Auth-landmine updates** — flip the two `ranked_lists` / `penalty_applications` books-denial tests to
+  assert a books domain user is now **allowed** to read.
+- **`Admin::Lists::ShowComponent`** — wizard button rendered for a games/music list, **not** for a books
+  list (nil `wizard_path`).
+- **`Books::Book#release_year`** — returns `first_published_year`.
+- **`ItemRankings::Calculator#calculate_score_penalty`** (legacy parity, exercised via books): book with a
+  year → graduated; `year_difference ≤ 0` → max; `> max_age` → none; **nil year → max**; **yearly-award
+  list → max**. Add a regression asserting the two edge cases hold for a music item too (shared behavior).
+- **Playwright** — `books/admin/lists.spec.ts` (index + show + add a book item via the live typeahead) and
+  `books/admin/ranking_configurations.spec.ts` (index + create).
+
+## Landmines
+
+- **`Books::Book` lacks `release_year`** — the whole reason the legacy penalty silently no-ops; the
+  shared calc's `respond_to?(:release_year)` guard hides it. Verify with a test that a book's penalty is
+  non-nil once `release_year` exists.
+- **RC `path:` gates auth** — adding it flips the `ranked_lists`/`penalty_applications` books-denial tests
+  red by design; update them (they assert *read* access now).
+- **`series`-style helper naming does not apply** — `lists`/`ranking_configurations` are regular plurals.
+- **`raise_on_missing_callback_actions` is on** — grow `before_action only: […]` per action as usual.
+- **Ship the DomainNav "Lists" + "Rankings" items with their routes** (every prior increment that forgot
+  the nav item shipped a dead sidebar).
+- **The nil-year / yearly-award edge cases are shared-calculator changes** — they touch music/games/movies
+  rankings, not just books; the tests must pin the intended cross-domain behavior.
+
+## Follow-ups (tracked, not in 6b)
+- **Shared-mutation write-gating PR** — gate `ranked_lists` / `penalty_applications` / `list_items` /
+  `list_penalties` mutations on domain write across all domains (the 6a `require_domain_write!` pattern),
+  closing the pre-existing viewer-write gap 6b newly exposes for books.
+- Inc 7 — full books admin Playwright suite mirroring games' nine specs.

--- a/web-app/app/components/admin/lists/show_component.html.erb
+++ b/web-app/app/components/admin/lists/show_component.html.erb
@@ -28,13 +28,16 @@
         </button>
       <% end %>
 
-      <%= link_to domain_config[:wizard_path_proc].call(list), class: "btn btn-secondary" do %>
-        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
-          <path fill-rule="evenodd" d="M5 2a1 1 0 011 1v1h1a1 1 0 010 2H6v1a1 1 0 01-2 0V6H3a1 1 0 010-2h1V3a1 1 0 011-1zm0 10a1 1 0 011 1v1h1a1 1 0 110 2H6v1a1 1 0 11-2 0v-1H3a1 1 0 110-2h1v-1a1 1 0 011-1zM12 2a1 1 0 01.967.744L14.146 7.2 17.5 9.134a1 1 0 010 1.732l-3.354 1.935-1.18 4.455a1 1 0 01-1.933 0L9.854 12.8 6.5 10.866a1 1 0 010-1.732l3.354-1.935 1.18-4.455A1 1 0 0112 2z" clip-rule="evenodd" />
-        </svg>
-        <span>Launch Wizard</span>
-        <% if list.wizard_state.present? && list.wizard_state["completed_at"].blank? %>
-          <span class="badge badge-warning badge-sm">In Progress</span>
+      <% wizard_link = domain_config[:wizard_path_proc].call(list) %>
+      <% if wizard_link.present? %>
+        <%= link_to wizard_link, class: "btn btn-secondary" do %>
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+            <path fill-rule="evenodd" d="M5 2a1 1 0 011 1v1h1a1 1 0 010 2H6v1a1 1 0 01-2 0V6H3a1 1 0 010-2h1V3a1 1 0 011-1zm0 10a1 1 0 011 1v1h1a1 1 0 110 2H6v1a1 1 0 11-2 0v-1H3a1 1 0 110-2h1v-1a1 1 0 011-1zM12 2a1 1 0 01.967.744L14.146 7.2 17.5 9.134a1 1 0 010 1.732l-3.354 1.935-1.18 4.455a1 1 0 01-1.933 0L9.854 12.8 6.5 10.866a1 1 0 010-1.732l3.354-1.935 1.18-4.455A1 1 0 0112 2z" clip-rule="evenodd" />
+          </svg>
+          <span>Launch Wizard</span>
+          <% if list.wizard_state.present? && list.wizard_state["completed_at"].blank? %>
+            <span class="badge badge-warning badge-sm">In Progress</span>
+          <% end %>
         <% end %>
       <% end %>
 

--- a/web-app/app/controllers/admin/books/lists_controller.rb
+++ b/web-app/app/controllers/admin/books/lists_controller.rb
@@ -1,0 +1,29 @@
+class Admin::Books::ListsController < Admin::ListsBaseController
+  include Admin::DomainScopedAuth
+
+  private
+
+  def policy_class = ::Books::ListPolicy
+
+  def item_label = "Book"
+
+  protected
+
+  def list_class = ::Books::List
+
+  def lists_path = admin_books_lists_path
+
+  def list_path(list) = admin_books_list_path(list)
+
+  def new_list_path = new_admin_books_list_path
+
+  def edit_list_path(list) = edit_admin_books_list_path(list)
+
+  def param_key = :books_list
+
+  def items_count_name = "books_count"
+
+  def listable_includes = [:authors]
+
+  def wizard_path(_list) = nil
+end

--- a/web-app/app/controllers/admin/books/ranking_configurations_controller.rb
+++ b/web-app/app/controllers/admin/books/ranking_configurations_controller.rb
@@ -1,0 +1,23 @@
+class Admin::Books::RankingConfigurationsController < Admin::RankingConfigurationsController
+  include Admin::DomainScopedAuth
+
+  private
+
+  def policy_class = ::Books::RankingConfigurationPolicy
+
+  def domain_name = "books"
+
+  def ranking_configuration_class = ::Books::RankingConfiguration
+
+  def ranking_configurations_path(**opts) = admin_books_ranking_configurations_path(**opts)
+
+  def ranking_configuration_path(config, **opts) = admin_books_ranking_configuration_path(config, **opts)
+
+  def new_ranking_configuration_path = new_admin_books_ranking_configuration_path
+
+  def edit_ranking_configuration_path(config) = edit_admin_books_ranking_configuration_path(config)
+
+  def execute_action_ranking_configuration_path(config, **opts) = execute_action_admin_books_ranking_configuration_path(config, **opts)
+
+  def index_action_ranking_configurations_path(**opts) = index_action_admin_books_ranking_configurations_path(**opts)
+end

--- a/web-app/app/lib/admin/domain_nav.rb
+++ b/web-app/app/lib/admin/domain_nav.rb
@@ -80,7 +80,8 @@ module Admin
           {label: "Authors", icon: :artist, path: -> { URL_HELPERS.admin_books_authors_path }},
           {label: "Series", icon: :series, path: -> { URL_HELPERS.admin_books_series_index_path }},
           {label: "Categories", icon: :category, path: -> { URL_HELPERS.admin_books_categories_path }},
-          {label: "Lists", icon: :list, path: -> { URL_HELPERS.admin_books_lists_path }}
+          {label: "Lists", icon: :list, path: -> { URL_HELPERS.admin_books_lists_path }},
+          {label: "Rankings", icon: :chart, path: -> { URL_HELPERS.admin_books_ranking_configurations_path }}
         ]
       }
     }.freeze

--- a/web-app/app/lib/admin/domain_nav.rb
+++ b/web-app/app/lib/admin/domain_nav.rb
@@ -79,7 +79,8 @@ module Admin
           {label: "Books", icon: :book, path: -> { URL_HELPERS.admin_books_books_path }},
           {label: "Authors", icon: :artist, path: -> { URL_HELPERS.admin_books_authors_path }},
           {label: "Series", icon: :series, path: -> { URL_HELPERS.admin_books_series_index_path }},
-          {label: "Categories", icon: :category, path: -> { URL_HELPERS.admin_books_categories_path }}
+          {label: "Categories", icon: :category, path: -> { URL_HELPERS.admin_books_categories_path }},
+          {label: "Lists", icon: :list, path: -> { URL_HELPERS.admin_books_lists_path }}
         ]
       }
     }.freeze

--- a/web-app/app/lib/admin/domain_routing.rb
+++ b/web-app/app/lib/admin/domain_routing.rb
@@ -120,7 +120,7 @@ module Admin
         domain: :books,
         list_type: "Books::List",
         ranked_item_includes: nil,
-        path: nil
+        path: ->(rc) { URL_HELPERS.admin_books_ranking_configuration_path(rc) }
       },
       "Movies::RankingConfiguration" => {
         domain: :movies,

--- a/web-app/app/lib/admin/domain_routing.rb
+++ b/web-app/app/lib/admin/domain_routing.rb
@@ -81,6 +81,13 @@ module Admin
         item_label: "Game",
         path: ->(l) { URL_HELPERS.admin_games_list_path(l) },
         autocomplete_path: -> { URL_HELPERS.search_admin_games_games_path }
+      },
+      "Books::List" => {
+        domain: :books,
+        listable_type: "Books::Book",
+        item_label: "Book",
+        path: ->(l) { URL_HELPERS.admin_books_list_path(l) },
+        autocomplete_path: -> { URL_HELPERS.search_admin_books_books_path }
       }
     }.freeze
 

--- a/web-app/app/lib/item_rankings/calculator.rb
+++ b/web-app/app/lib/item_rankings/calculator.rb
@@ -88,30 +88,16 @@ module ItemRankings
     end
 
     def calculate_score_penalty(list, list_item)
-      return nil unless list.year_published.present?
-
-      # Get the item to check its release year
       item = list_item.listable
-      return nil unless item&.respond_to?(:release_year) && item.release_year.present?
+      item_year = item.respond_to?(:release_year) ? item.release_year : nil
 
-      max_age = ranking_configuration.max_list_dates_penalty_age
-      max_penalty_percentage = ranking_configuration.max_list_dates_penalty_percentage
-
-      return nil if max_age.nil? || max_penalty_percentage.nil?
-
-      year_difference = list.year_published - item.release_year
-
-      penalty = if year_difference <= 0
-        max_penalty_percentage / 100.0
-      elsif year_difference > max_age
-        nil
-      else
-        # Apply graduated penalty based on age difference
-        p = ((max_age - year_difference).to_f / max_age) * max_penalty_percentage
-        p / 100.0
-      end
-
-      (penalty == 0) ? nil : penalty
+      ItemRankings::DatePenalty.call(
+        list_year: list.year_published,
+        item_year: item_year,
+        yearly_award: list.yearly_award?,
+        max_age: ranking_configuration.max_list_dates_penalty_age,
+        max_penalty_percentage: ranking_configuration.max_list_dates_penalty_percentage
+      )
     end
 
     def update_ranked_items(ranking_data)

--- a/web-app/app/lib/item_rankings/date_penalty.rb
+++ b/web-app/app/lib/item_rankings/date_penalty.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module ItemRankings
+  # Pure legacy per-item "list dates" recency penalty, mirroring the legacy
+  # TheGreatestBooks calculate_score_penalty. Returns a penalty fraction (0..1)
+  # or nil (no penalty). Order matches legacy: award lists and items with an
+  # unknown year take the full penalty, checked before the list-year guard.
+  class DatePenalty
+    def self.call(list_year:, item_year:, yearly_award:, max_age:, max_penalty_percentage:)
+      return nil if max_age.nil? || max_penalty_percentage.nil?
+
+      return max_penalty_percentage / 100.0 if yearly_award || item_year.nil?
+
+      return nil if list_year.nil?
+
+      year_difference = list_year - item_year
+
+      penalty = if year_difference <= 0
+        max_penalty_percentage / 100.0
+      elsif year_difference > max_age
+        nil
+      else
+        p = ((max_age - year_difference).to_f / max_age) * max_penalty_percentage
+        p / 100.0
+      end
+
+      (penalty == 0) ? nil : penalty
+    end
+  end
+end

--- a/web-app/app/lib/item_rankings/date_penalty.rb
+++ b/web-app/app/lib/item_rankings/date_penalty.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
 module ItemRankings
-  # Pure legacy per-item "list dates" recency penalty, mirroring the legacy
-  # TheGreatestBooks calculate_score_penalty. Returns a penalty fraction (0..1)
-  # or nil (no penalty). Order matches legacy: award lists and items with an
-  # unknown year take the full penalty, checked before the list-year guard.
   class DatePenalty
     def self.call(list_year:, item_year:, yearly_award:, max_age:, max_penalty_percentage:)
       return nil if max_age.nil? || max_penalty_percentage.nil?

--- a/web-app/app/models/books/book.rb
+++ b/web-app/app/models/books/book.rb
@@ -76,8 +76,6 @@ class Books::Book < ApplicationRecord
 
   scope :selectable, -> { where(book_kind: :standalone) }
 
-  # The item-ranking calculator and CSV export use the generic `release_year`
-  # interface that every other medium exposes; books store it as first_published_year.
   def release_year
     first_published_year
   end

--- a/web-app/app/models/books/book.rb
+++ b/web-app/app/models/books/book.rb
@@ -76,6 +76,12 @@ class Books::Book < ApplicationRecord
 
   scope :selectable, -> { where(book_kind: :standalone) }
 
+  # The item-ranking calculator and CSV export use the generic `release_year`
+  # interface that every other medium exposes; books store it as first_published_year.
+  def release_year
+    first_published_year
+  end
+
   def as_indexed_json
     {
       title: title,

--- a/web-app/app/views/admin/books/lists/_form.html.erb
+++ b/web-app/app/views/admin/books/lists/_form.html.erb
@@ -1,0 +1,1 @@
+<%= render Admin::Lists::FormComponent.new(list: @list, domain_config: domain_config) %>

--- a/web-app/app/views/admin/books/lists/_table.html.erb
+++ b/web-app/app/views/admin/books/lists/_table.html.erb
@@ -1,0 +1,1 @@
+<%= render Admin::Lists::TableComponent.new(lists: lists, pagy: pagy, domain_config: domain_config, search_query: search_query) %>

--- a/web-app/app/views/admin/books/lists/edit.html.erb
+++ b/web-app/app/views/admin/books/lists/edit.html.erb
@@ -1,0 +1,2 @@
+<% content_for :title, "Edit #{@list.name}" %>
+<%= render Admin::Lists::EditComponent.new(list: @list, domain_config: domain_config) %>

--- a/web-app/app/views/admin/books/lists/index.html.erb
+++ b/web-app/app/views/admin/books/lists/index.html.erb
@@ -1,0 +1,2 @@
+<% content_for :title, "Book Lists" %>
+<%= render Admin::Lists::IndexComponent.new(lists: @lists, pagy: @pagy, domain_config: domain_config, selected_status: @selected_status, search_query: @search_query) %>

--- a/web-app/app/views/admin/books/lists/new.html.erb
+++ b/web-app/app/views/admin/books/lists/new.html.erb
@@ -1,0 +1,2 @@
+<% content_for :title, "New Book List" %>
+<%= render Admin::Lists::NewComponent.new(list: @list, domain_config: domain_config) %>

--- a/web-app/app/views/admin/books/lists/show.html.erb
+++ b/web-app/app/views/admin/books/lists/show.html.erb
@@ -1,0 +1,2 @@
+<% content_for :title, @list.name %>
+<%= render Admin::Lists::ShowComponent.new(list: @list, domain_config: domain_config) %>

--- a/web-app/config/routes.rb
+++ b/web-app/config/routes.rb
@@ -321,6 +321,8 @@ Rails.application.routes.draw do
           get :search
         end
       end
+
+      resources :lists
     end
 
     root to: "books/default#index", as: :books_root

--- a/web-app/config/routes.rb
+++ b/web-app/config/routes.rb
@@ -323,6 +323,11 @@ Rails.application.routes.draw do
       end
 
       resources :lists
+
+      resources :ranking_configurations do
+        member { post :execute_action }
+        collection { post :index_action }
+      end
     end
 
     root to: "books/default#index", as: :books_root

--- a/web-app/e2e/tests/books/admin/lists.spec.ts
+++ b/web-app/e2e/tests/books/admin/lists.spec.ts
@@ -1,0 +1,17 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Books admin — lists", () => {
+  test("lists index and links to New List", async ({ page }) => {
+    await page.goto("/admin/lists");
+    await expect(page.getByRole("heading", { name: "Book Lists", level: 1 })).toBeVisible();
+  });
+
+  test("creates a list and shows it without a wizard button", async ({ page }) => {
+    const name = `E2E List ${Date.now()}`;
+    await page.goto("/admin/lists/new");
+    await page.locator('input[name="books_list[name]"]').fill(name);
+    await page.getByRole("button", { name: "Create Book List" }).click();
+    await expect(page.getByRole("heading", { name, level: 1 })).toBeVisible();
+    await expect(page.getByRole("link", { name: "Launch Wizard" })).toHaveCount(0);
+  });
+});

--- a/web-app/e2e/tests/books/admin/ranking-configurations.spec.ts
+++ b/web-app/e2e/tests/books/admin/ranking-configurations.spec.ts
@@ -1,0 +1,16 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Books admin — ranking configurations", () => {
+  test("lists ranking configurations", async ({ page }) => {
+    await page.goto("/admin/ranking_configurations");
+    await expect(page.getByRole("heading", { level: 1 }).first()).toBeVisible();
+  });
+
+  test("creates a ranking configuration", async ({ page }) => {
+    const name = `E2E RC ${Date.now()}`;
+    await page.goto("/admin/ranking_configurations/new");
+    await page.locator('input[name="ranking_configuration[name]"]').fill(name);
+    await page.getByRole("button", { name: /Create|Save/ }).click();
+    await expect(page.getByRole("heading", { name, level: 1 })).toBeVisible();
+  });
+});

--- a/web-app/test/controllers/admin/books/lists_controller_test.rb
+++ b/web-app/test/controllers/admin/books/lists_controller_test.rb
@@ -1,0 +1,70 @@
+require "test_helper"
+
+module Admin
+  module Books
+    class ListsControllerTest < ActionDispatch::IntegrationTest
+      setup do
+        @admin_user = users(:admin_user)
+        @regular_user = users(:regular_user)
+        host! Rails.application.config.domains[:books]
+
+        @list = ::Books::List.create!(name: "Test Books List", status: :approved, year_published: 2020)
+      end
+
+      test "index redirects unauthenticated users" do
+        get admin_books_lists_path
+        assert_redirected_to books_root_path
+      end
+
+      test "index redirects a regular user" do
+        sign_in_as(@regular_user, stub_auth: true)
+        get admin_books_lists_path
+        assert_redirected_to books_root_path
+      end
+
+      test "index allows an admin" do
+        sign_in_as(@admin_user, stub_auth: true)
+        get admin_books_lists_path
+        assert_response :success
+      end
+
+      test "index allows a books domain editor" do
+        @regular_user.domain_roles.create!(domain: :books, permission_level: :editor)
+        sign_in_as(@regular_user, stub_auth: true)
+        get admin_books_lists_path
+        assert_response :success
+      end
+
+      test "show renders without a wizard button" do
+        sign_in_as(@admin_user, stub_auth: true)
+        get admin_books_list_path(@list)
+        assert_response :success
+        assert_no_match "Launch Wizard", response.body
+      end
+
+      test "creates a list for an admin" do
+        sign_in_as(@admin_user, stub_auth: true)
+        assert_difference("::Books::List.count", 1) do
+          post admin_books_lists_path, params: {books_list: {name: "New List", status: "unapproved"}}
+        end
+        assert_redirected_to admin_books_list_path(::Books::List.order(:id).last)
+      end
+
+      test "updates a list for an admin" do
+        sign_in_as(@admin_user, stub_auth: true)
+        patch admin_books_list_path(@list), params: {books_list: {name: "Renamed"}}
+        @list.reload
+        assert_redirected_to admin_books_list_path(@list)
+        assert_equal "Renamed", @list.name
+      end
+
+      test "destroys a list for an admin" do
+        sign_in_as(@admin_user, stub_auth: true)
+        assert_difference("::Books::List.count", -1) do
+          delete admin_books_list_path(@list)
+        end
+        assert_redirected_to admin_books_lists_path
+      end
+    end
+  end
+end

--- a/web-app/test/controllers/admin/books/ranking_configurations_controller_test.rb
+++ b/web-app/test/controllers/admin/books/ranking_configurations_controller_test.rb
@@ -1,0 +1,68 @@
+require "test_helper"
+
+module Admin
+  module Books
+    class RankingConfigurationsControllerTest < ActionDispatch::IntegrationTest
+      setup do
+        @admin_user = users(:admin_user)
+        @regular_user = users(:regular_user)
+        @rc = ranking_configurations(:books_global)
+        host! Rails.application.config.domains[:books]
+      end
+
+      test "index redirects unauthenticated users" do
+        get admin_books_ranking_configurations_path
+        assert_redirected_to books_root_path
+      end
+
+      test "index redirects a regular user" do
+        sign_in_as(@regular_user, stub_auth: true)
+        get admin_books_ranking_configurations_path
+        assert_redirected_to books_root_path
+      end
+
+      test "index allows an admin" do
+        sign_in_as(@admin_user, stub_auth: true)
+        get admin_books_ranking_configurations_path
+        assert_response :success
+      end
+
+      test "index allows a books domain viewer to read" do
+        @regular_user.domain_roles.create!(domain: :books, permission_level: :viewer)
+        sign_in_as(@regular_user, stub_auth: true)
+        get admin_books_ranking_configurations_path
+        assert_response :success
+      end
+
+      test "show for an admin" do
+        sign_in_as(@admin_user, stub_auth: true)
+        get admin_books_ranking_configuration_path(@rc)
+        assert_response :success
+      end
+
+      test "index tolerates a sort-injection attempt" do
+        sign_in_as(@admin_user, stub_auth: true)
+        assert_nothing_raised do
+          get admin_books_ranking_configurations_path(sort: "'; DROP TABLE ranking_configurations; --")
+        end
+        assert_response :success
+      end
+
+      test "creates a ranking configuration for an admin" do
+        sign_in_as(@admin_user, stub_auth: true)
+        assert_difference("::Books::RankingConfiguration.count", 1) do
+          post admin_books_ranking_configurations_path, params: {ranking_configuration: {name: "New Books RC"}}
+        end
+        assert_redirected_to admin_books_ranking_configuration_path(::Books::RankingConfiguration.order(:id).last)
+      end
+
+      test "does not allow a books editor to create (manage required)" do
+        @regular_user.domain_roles.create!(domain: :books, permission_level: :editor)
+        sign_in_as(@regular_user, stub_auth: true)
+        assert_no_difference("::Books::RankingConfiguration.count") do
+          post admin_books_ranking_configurations_path, params: {ranking_configuration: {name: "Nope"}}
+        end
+      end
+    end
+  end
+end

--- a/web-app/test/controllers/admin/music/ranked_items_controller_test.rb
+++ b/web-app/test/controllers/admin/music/ranked_items_controller_test.rb
@@ -159,13 +159,13 @@ class Admin::Music::RankedItemsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
-  test "should deny access to a books ranking configuration for a user with only a books domain role" do
+  test "should allow access to a books ranking configuration for a user with only a books domain role" do
     books_config = ranking_configurations(:books_global)
     @regular_user.domain_roles.create!(domain: :books, permission_level: :viewer)
     sign_in_as(@regular_user, stub_auth: true)
 
     get admin_ranking_configuration_ranked_items_path(books_config)
 
-    assert_redirected_to music_root_path
+    assert_response :success
   end
 end

--- a/web-app/test/controllers/admin/penalty_applications_controller_test.rb
+++ b/web-app/test/controllers/admin/penalty_applications_controller_test.rb
@@ -223,14 +223,14 @@ module Admin
       assert_redirected_to admin_albums_ranking_configuration_path(@album_config)
     end
 
-    test "should deny access to a books ranking configuration for a user with only a books domain role" do
+    test "should allow access to a books ranking configuration for a user with only a books domain role" do
       books_config = ranking_configurations(:books_global)
       @regular_user.domain_roles.create!(domain: :books, permission_level: :viewer)
       sign_in_as(@regular_user, stub_auth: true)
 
       get admin_ranking_configuration_penalty_applications_path(books_config)
 
-      assert_redirected_to music_root_path
+      assert_response :success
     end
   end
 end

--- a/web-app/test/controllers/admin/ranked_lists_controller_test.rb
+++ b/web-app/test/controllers/admin/ranked_lists_controller_test.rb
@@ -180,14 +180,14 @@ module Admin
       assert_equal @song_list, RankedList.last.list
     end
 
-    test "should deny access to a books ranking configuration for a user with only a books domain role" do
+    test "should allow access to a books ranking configuration for a user with only a books domain role" do
       books_config = ranking_configurations(:books_global)
       @regular_user.domain_roles.create!(domain: :books, permission_level: :viewer)
       sign_in_as(@regular_user, stub_auth: true)
 
       get admin_ranking_configuration_ranked_lists_path(books_config)
 
-      assert_redirected_to music_root_path
+      assert_response :success
     end
 
     test "should allow access to a games ranking configuration for a user with only a games domain role" do

--- a/web-app/test/lib/admin/domain_nav_test.rb
+++ b/web-app/test/lib/admin/domain_nav_test.rb
@@ -114,5 +114,11 @@ module Admin
       assert item, "books nav is missing a Lists item"
       assert_equal "/admin/lists", item[:path]
     end
+
+    test "the books nav includes a Rankings item" do
+      item = Admin::DomainNav.config_for(:books)[:items].find { |i| i[:label] == "Rankings" }
+      assert item, "books nav is missing a Rankings item"
+      assert_equal "/admin/ranking_configurations", item[:path]
+    end
   end
 end

--- a/web-app/test/lib/admin/domain_nav_test.rb
+++ b/web-app/test/lib/admin/domain_nav_test.rb
@@ -108,5 +108,11 @@ module Admin
       assert categories_item[:icon].present?
       assert config[:categories_search_path].present?
     end
+
+    test "the books nav includes a Lists item" do
+      item = Admin::DomainNav.config_for(:books)[:items].find { |i| i[:label] == "Lists" }
+      assert item, "books nav is missing a Lists item"
+      assert_equal "/admin/lists", item[:path]
+    end
   end
 end

--- a/web-app/test/lib/admin/domain_routing_test.rb
+++ b/web-app/test/lib/admin/domain_routing_test.rb
@@ -96,7 +96,7 @@ module Admin
         {rc: ranking_configurations(:music_songs_global), path_prefix: "/admin/songs/ranking_configurations"},
         {rc: ranking_configurations(:music_artists_global), path_prefix: "/admin/artists/ranking_configurations"},
         {rc: ranking_configurations(:games_global), path_prefix: "/admin/ranking_configurations"},
-        {rc: ranking_configurations(:books_global), path_prefix: nil},
+        {rc: ranking_configurations(:books_global), path_prefix: "/admin/ranking_configurations"},
         {rc: ranking_configurations(:movies_global), path_prefix: nil}
       ].each do |example|
         rc = example[:rc]
@@ -112,10 +112,10 @@ module Admin
     end
 
     test "ranking_configuration_config returns a nil path for domains without an admin" do
-      config = Admin::DomainRouting.ranking_configuration_config(::Books::RankingConfiguration.new)
+      config = Admin::DomainRouting.ranking_configuration_config(::Movies::RankingConfiguration.new)
 
-      assert_equal :books, config[:domain]
-      assert_equal "Books::List", config[:list_type]
+      assert_equal :movies, config[:domain]
+      assert_equal "Movies::List", config[:list_type]
       assert_nil config[:path]
     end
 
@@ -214,6 +214,12 @@ module Admin
         Admin::DomainRouting.category_items_path_for(book)
       assert_equal Rails.application.routes.url_helpers.admin_books_author_category_items_path(author),
         Admin::DomainRouting.category_items_path_for(author)
+    end
+
+    test "RANKING_CONFIGURATIONS resolves a books RC path" do
+      rc = ranking_configurations(:books_global)
+      assert_equal Rails.application.routes.url_helpers.admin_books_ranking_configuration_path(rc),
+        Admin::DomainRouting.ranking_configuration_config(rc)[:path]
     end
   end
 end

--- a/web-app/test/lib/admin/domain_routing_test.rb
+++ b/web-app/test/lib/admin/domain_routing_test.rb
@@ -200,6 +200,13 @@ module Admin
       assert_equal series, resolved
     end
 
+    test "LISTS resolves a books list to the books book typeahead" do
+      config = Admin::DomainRouting.list_config(::Books::List.new)
+      assert_equal :books, config[:domain]
+      assert_equal "Book", config[:item_label]
+      assert_equal Rails.application.routes.url_helpers.search_admin_books_books_path, config[:autocomplete_path]
+    end
+
     test "category_items_path_for resolves for a books book and author" do
       book = books_books(:war_and_peace)
       author = books_authors(:tolstoy)

--- a/web-app/test/lib/item_rankings/date_penalty_test.rb
+++ b/web-app/test/lib/item_rankings/date_penalty_test.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module ItemRankings
+  class DatePenaltyTest < ActiveSupport::TestCase
+    def penalty(list_year: 2000, item_year: 1980, yearly_award: false, max_age: 50, max_penalty_percentage: 80)
+      ItemRankings::DatePenalty.call(
+        list_year: list_year, item_year: item_year, yearly_award: yearly_award,
+        max_age: max_age, max_penalty_percentage: max_penalty_percentage
+      )
+    end
+
+    test "graduated penalty for an item older than the list within max_age" do
+      # year_difference = 20; ((50-20)/50)*80/100 = 0.48
+      assert_in_delta 0.48, penalty(item_year: 1980), 0.0001
+    end
+
+    test "max penalty when the item is newer than the list" do
+      assert_in_delta 0.80, penalty(item_year: 2005), 0.0001
+    end
+
+    test "no penalty when the item is older than max_age" do
+      assert_nil penalty(item_year: 1940) # diff 60 > 50
+    end
+
+    test "max penalty when the item has no year" do
+      assert_in_delta 0.80, penalty(item_year: nil), 0.0001
+    end
+
+    test "a yearly-award list forces max penalty even with a good year gap" do
+      assert_in_delta 0.80, penalty(item_year: 1940, yearly_award: true), 0.0001
+    end
+
+    test "a yearly-award list max-penalizes even with no list year" do
+      assert_in_delta 0.80, penalty(list_year: nil, item_year: 1980, yearly_award: true), 0.0001
+    end
+
+    test "nil when the penalty config is incomplete" do
+      assert_nil penalty(max_age: nil)
+      assert_nil penalty(max_penalty_percentage: nil)
+    end
+
+    test "nil when the list has no year and the item is not award/nil-year" do
+      assert_nil penalty(list_year: nil)
+    end
+  end
+end

--- a/web-app/test/models/books/book_test.rb
+++ b/web-app/test/models/books/book_test.rb
@@ -113,6 +113,15 @@ module Books
       assert_includes books_books(:war_and_peace).as_indexed_json[:author_ids], books_authors(:tolstoy).id
     end
 
+    test "release_year returns first_published_year" do
+      book = ::Books::Book.new(first_published_year: 1869)
+      assert_equal 1869, book.release_year
+    end
+
+    test "release_year is nil when first_published_year is nil" do
+      assert_nil ::Books::Book.new(first_published_year: nil).release_year
+    end
+
     # SearchIndexable concern tests
     test "should create search index request on create" do
       assert_difference "SearchIndexRequest.count", 1 do


### PR DESCRIPTION
## Increment 6b — Books Lists + Ranking Configurations + legacy date-penalty parity

Part of the books admin (umbrella `docs/superpowers/specs/2026-07-13-books-admin-ui-design.md`, increment 6 — split into 6a categories [PR #174] and **6b, this PR**). Design + plan: `docs/superpowers/specs/2026-07-22-books-admin-6b-lists-rankings-design.md`, `docs/superpowers/plans/2026-07-22-books-admin-6b-lists-rankings.md`.

### What's in it

- **`Books::List` admin** at `/admin/lists` — thin `Admin::Books::ListsController` (one-line shared-component views), `Books::List` in the `LISTS` registry so the show-page "add item" typeahead searches books. **No wizard**: `wizard_path` returns `nil` and the shared `Admin::Lists::ShowComponent` now guards the "Launch Wizard" button on the path being present (behavior-neutral for music/games). List items ride the existing shared `Admin::ListItemsController`.
- **`Books::RankingConfiguration` admin** at `/admin/ranking_configurations` — thin controller with **zero new views** (inherits the shared RC views). Registering the RC's registry `path:` gates books-domain auth, so books-domain users reach the shared ranked-lists / penalty / ranked-items views for books RCs — intentionally flipping three denial tests to allowed (`ranked_lists`, `ranked_items`, `penalty_applications`). "Refresh Rankings" / "Bulk Calculate Weights" work with no new code.
- **Legacy date-penalty parity** — the reframed D8. `calculate_books_year_range` turned out to be a red herring (dead code for books; no books RC applies the temporal-coverage penalty, and the legacy app has no year-range concept). The legacy date penalty is a *per-book recency* penalty, ported in the shared `ItemRankings::Calculator` but silently skipped for books because `Books::Book` exposes `first_published_year`, not the generic `release_year` the calculator checks. Fix:
  - `Books::Book#release_year` → `first_published_year` (also closes the known `MyListsController#csv_row` gap).
  - Extract the pure penalty math into a public, unit-tested `ItemRankings::DatePenalty` PORO (calculator's `calculate_score_penalty` becomes a thin adapter), reproducing the legacy branch order: a yearly-award list or an item with no publication year takes the full penalty, checked **before** the list-year guard. This is a shared change (inert for music/games award lists — 0 exist; re-ranks ~1% of their nil-year items).

### Testing
- Full suite green: **4835 runs, 12,908 assertions, 0 failures**. `standardrb` clean. Playwright **5/5** (books lists + ranking-configurations, run live).
- New: `DatePenalty` PORO unit test (all legacy branches incl. award-with-nil-list-year), `Books::Book#release_year`, books lists + RC controller tests, `LISTS`/`RANKING_CONFIGURATIONS` registry units, and the three denial-test flips (assert books-domain read access).

### Reviewer note (accepted / deferred, decision 6b-4)
Registering the books RC path grants books-domain users **access** to the shared `ranked_lists` / `penalty_applications` controllers, which have no write gate — so a books *viewer* can also mutate them (create/destroy ranked-lists, mutate penalty-applications), the **same pre-existing gap** music/games already have. This is deferred to a standalone shared-mutation write-gating PR (the `require_domain_write!` pattern from 6a) that will close it across all domains. 6b introduces no new mechanism — it exposes the existing one for books.

### Deferred / out of scope
- Shared-mutation write-gating (above) — own follow-up PR.
- `calculate_books_year_range` left untouched (moot for books).
- Inc 7 — full books admin Playwright suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
