### PR TITLE
Fix books ranking refresh: force RC algorithm_version to 1 on import

### DIFF
--- a/web-app/app/lib/services/books_migration/ranking_configuration_transformer.rb
+++ b/web-app/app/lib/services/books_migration/ranking_configuration_transformer.rb
@@ -20,7 +20,7 @@ module Services
           primary: attrs["primary"],
           archived: false,
           published_at: attrs["published_at"],
-          algorithm_version: attrs["algorithm_version"],
+          algorithm_version: 1,
           inherit_penalties: attrs["inherit_list_cons"],
           min_list_weight: attrs["min_list_weight"],
           max_list_dates_penalty_age: attrs["max_age_for_penalty"],

--- a/web-app/test/lib/services/books_migration/ranking_configuration_transformer_test.rb
+++ b/web-app/test/lib/services/books_migration/ranking_configuration_transformer_test.rb
@@ -72,7 +72,12 @@ class Services::BooksMigration::RankingConfigurationTransformerTest < ActiveSupp
     assert_equal(-50, out[:min_list_weight])
     assert_equal 2.0, out[:bonus_pool_percentage]
     assert_equal 1.5, out[:exponent]
-    assert_equal 4, out[:algorithm_version]
+    assert_equal 1, out[:algorithm_version]
+  end
+
+  test "forces algorithm_version to 1 regardless of the legacy value" do
+    assert_equal 1, T.call(legacy.merge("algorithm_version" => 4))[:algorithm_version]
+    assert_equal 1, T.call(legacy.merge("algorithm_version" => 2))[:algorithm_version]
   end
 
   test "preserves timestamps" do


### PR DESCRIPTION
## Fix: books ranking refresh fails with "Unsupported algorithm version: 4"

Refreshing / bulk-calculating weights for any books ranking configuration raised `Unsupported algorithm version: 4` for every list.

### Root cause
The books-migration `RankingConfigurationTransformer` copied the legacy `algorithm_version` **verbatim**, and the legacy TheGreatestBooks ranking configurations used version **4**. The new app only implements `Rankings::WeightCalculatorV1` (version 1) — `Rankings::WeightCalculator.for_version` raises for anything else. Every other domain's RCs are version 1 (created in the new app), so only books were affected. All 4 migrated books RCs carried version 4.

### Fix
- `RankingConfigurationTransformer` now **forces `algorithm_version: 1`** on import instead of passing the legacy value through, so a re-import produces the correct version. Tests updated (the field-map assertion now expects 1, plus a focused test that it forces 1 regardless of the legacy input).
- The 4 already-migrated books RCs were corrected to version 1 directly in the dev database (per-record `update!`, non-destructive; the only callback that fires is the primary-uniqueness check, a no-op here). This data isn't in production and re-importing takes hours, so the rows were fixed in place; a future re-import would now also yield 1.

### Verification
- End-to-end: `Rankings::BulkWeightCalculator` on RC #6 ("The Best Books of 2023") → **30 processed, 0 errors** (previously all failed).
- `Rankings::WeightCalculator.for_ranked_list` now dispatches to `WeightCalculatorV1` and computes real weights.
- Full suite **4836 / 0**; books-migration suite 201 / 0; `standardrb` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
