### PR TITLE
Descriptions increment (b1): backfill the games/music description columns

### DIFF
--- a/docs/superpowers/plans/2026-07-29-descriptions-b1-column-backfill.md
+++ b/docs/superpowers/plans/2026-07-29-descriptions-b1-column-backfill.md
@@ -395,6 +395,44 @@ Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
 - A second run changes nothing and preserves an edited row's rank and content
 - No schema change, no page behaviour change — the eleven `description` columns are still authoritative
 
+## Production run
+
+Development already has this data (see "Verified current state" above and the dev-run steps in Task
+2); production does not yet.
+
+```bash
+bin/rails data_migration:description_columns
+```
+
+**Ordering dependency:** increment (d) flips five public views to read `primary_description`. If
+`data_migration:description_columns` has not been run in production before (d) deploys, every games
+and music page silently loses its description.
+
+**Verification is invariant-based, not the hardcoded `11382` used for the dev run above.** Production
+will legitimately produce a different total: dev's games/music data came from a production backup of
+unknown age, and IGDB/AI imports run continuously against production. The invariant that holds in any
+environment is that, for each model in `SOURCE_BY_MODEL`, its `Description` row count equals the number
+of source records with a non-blank `description`:
+
+```bash
+bin/rails runner '
+ok = true
+Services::DescriptionColumnBackfill::SOURCE_BY_MODEL.each_key do |model_name|
+  model = model_name.constantize
+  expected = model.where("description IS NOT NULL AND btrim(description) <> ?", "").count
+  actual = Description.where(describable_type: model_name).count
+  match = expected == actual
+  ok &&= match
+  puts "#{model_name}: expected=#{expected} actual=#{actual} #{match ? "OK" : "MISMATCH"}"
+end
+puts ok ? "invariant holds" : "invariant VIOLATED"
+'
+```
+
+Expected: `invariant holds`, with each line showing `expected == actual` regardless of what the total
+is. A `MISMATCH` line names the model to start diagnosing from — the dev run's `11382`/per-model split
+above is **not** the number to expect in production.
+
 ## Not in this increment
 
 b2 adds `BookDescriptionMigrator` (139,851 rows) and `AuthorDescriptionMigrator` (46,784), both of which need the `legacy_books` connection, plus the books/authors safety net that has to run after them. (c) cuts the write paths over. (d) cuts the read paths over. (e) drops the eleven columns.

--- a/docs/superpowers/plans/2026-07-29-descriptions-b1-column-backfill.md
+++ b/docs/superpowers/plans/2026-07-29-descriptions-b1-column-backfill.md
@@ -411,16 +411,18 @@ and music page silently loses its description.
 **Verification is invariant-based, not the hardcoded `11382` used for the dev run above.** Production
 will legitimately produce a different total: dev's games/music data came from a production backup of
 unknown age, and IGDB/AI imports run continuously against production. The invariant that holds in any
-environment is that, for each model in `SOURCE_BY_MODEL`, its `Description` row count equals the number
-of source records with a non-blank `description`:
+environment is that, for each model in `SOURCE_BY_MODEL`, the count of `Description` rows **at the key
+this backfill writes** equals the number of source records with a non-blank `description`:
 
 ```bash
 bin/rails runner '
 ok = true
-Services::DescriptionColumnBackfill::SOURCE_BY_MODEL.each_key do |model_name|
+Services::DescriptionColumnBackfill::SOURCE_BY_MODEL.each do |model_name, source|
   model = model_name.constantize
-  expected = model.where("description IS NOT NULL AND btrim(description) <> ?", "").count
-  actual = Description.where(describable_type: model_name).count
+  expected = model.where("btrim(coalesce(description, ?), ?) <> ?", "", " \t\n\r\f\v", "").count
+  actual = Description.where(
+    describable_type: model_name, source: source, kind: :summary, locale: "en", source_name: nil
+  ).count
   match = expected == actual
   ok &&= match
   puts "#{model_name}: expected=#{expected} actual=#{actual} #{match ? "OK" : "MISMATCH"}"
@@ -428,6 +430,19 @@ end
 puts ok ? "invariant holds" : "invariant VIOLATED"
 '
 ```
+
+Two details in that query are load-bearing, and both were review findings:
+
+**`actual` is scoped to `(source, kind, locale, source_name)`, not just `describable_type`.** A record
+having a description from another source is an explicitly supported state once increment (c)'s write
+paths and admin editing ship — an album can carry both an `:ai_generated` row from this backfill and a
+`:manual` row an editor wrote. An unscoped count includes both, so a *complete* backfill reports
+`MISMATCH`. Verified: adding one editorial row moved `Music::Album` from `actual=3649` to `actual=3650`
+against `expected=3649`.
+
+**`expected` trims the same characters Ruby's `.blank?` does**, not just ASCII spaces. The backfill
+skips on `.presence`, so a description of `"\t\n"` produces no row; single-argument `btrim` would count
+it as non-blank and report a false `MISMATCH`. `coalesce` folds the `NULL` case into the same test.
 
 Expected: `invariant holds`, with each line showing `expected == actual` regardless of what the total
 is. A `MISMATCH` line names the model to start diagnosing from — the dev run's `11382`/per-model split

--- a/docs/superpowers/plans/2026-07-29-descriptions-b1-column-backfill.md
+++ b/docs/superpowers/plans/2026-07-29-descriptions-b1-column-backfill.md
@@ -1,0 +1,402 @@
+# Descriptions Subsystem — Increment (b1): Games/Music Column Backfill — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move the five in-app games/music `description` columns onto `Description` rows — 11,382 of them — without touching the columns themselves or changing any page.
+
+**Architecture:** A standalone `Services::DescriptionColumnBackfill` streams each model, skips blank values, and bulk-inserts `Description` rows with `insert_all` (ON CONFLICT DO NOTHING). It deliberately does **not** subclass `Services::BooksMigration::BulkUpsertMigrator`: that base and its parent both stream from a `legacy_model` and wrap the load in `BooksMigration.without_search_indexing`, and this backfill has neither. A rake task under the existing `data_migration:` namespace runs it.
+
+**Tech Stack:** Rails 8.1.3, Ruby 3.4.7, PostgreSQL 17.4, Minitest + fixtures.
+
+**Spec:** `docs/superpowers/specs/2026-07-27-descriptions-subsystem-design.md` (increment b1)
+
+## Global Constraints
+
+- Run every command from `web-app/`. Docs live at the project root in `docs/`, not `web-app/docs/`.
+- Lint with `bundle exec standardrb` — **not** `bin/rubocop`. `--fix` autocorrects.
+- Do **not** run `bin/brakeman`.
+- **Never run a destructive DB command against development.** `db:migrate` / `db:test:prepare` are fine; `db:drop`/`db:reset`/`db:schema:load` and `ActiveRecord::FixtureSet.create_fixtures` are hard-blocked by a `PreToolUse` hook and would destroy books data that exists **only** in development. This increment needs no schema change at all.
+- Services live in `app/lib/services/`, **not** `app/services/`. Tests mirror to `test/lib/services/`.
+- Skinny models, fat services. Result pattern: `Result = Struct.new(:success?, :data, :errors, keyword_init: true)` — `keyword_init` is kept deliberately (a Standard cop is disabled for it).
+- **No code comments** unless a comment explains something non-obvious the code cannot say itself.
+- **`insert_all`, never `upsert_all`.** Verified on PG 17: an `upsert_all` re-run resets a human's `rank: :preferred` back to `:normal` and overwrites edited content, violating D5 ("importers may never write `rank`"). `insert_all` with `unique_by:` leaves existing rows untouched. Both cast enum symbols correctly.
+- Every row written here is `kind: :summary`, `locale: "en"`, `rank: :normal`, `source_name: nil`, `license: nil`, `source_url: nil`, `retrieved_at: nil`. `source_name` **must** be nil — the `descriptions_source_name_matches_source` check constraint rejects a named source that carries one.
+
+## Scope note
+
+Increment b1 covers **only** the five games/music columns. The spec's books/authors safety net (~50 books, ~21 authors created in-app rather than migrated) depends on the legacy backfill having already run, so it belongs to **b2**, after `BookDescriptionMigrator` and `AuthorDescriptionMigrator`.
+
+## Verified current state (2026-07-29)
+
+| Model | non-null `description` | non-empty | empty-string |
+|---|---|---|---|
+| `Games::Game` | 1,602 | **1,602** | 0 |
+| `Games::Company` | 673 | **658** | 15 |
+| `Games::Series` | 15 | **5** | 10 |
+| `Music::Album` | 3,662 | **3,649** | 13 |
+| `Music::Artist` | 5,471 | **5,468** | 3 |
+| **total** | | **11,382** | **41** |
+
+Those **41 empty-string rows are the point of the `.presence` guard.** A `build_rows` testing truthiness instead would try to insert 41 blank-content rows, and `descriptions_content_not_blank` would reject the whole batch with a `CheckViolation`. This is not a hypothetical — it fires on the first run.
+
+`Description.count` is currently 0. `Music::Album.polymorphic_name` → `"Music::Album"`, so `record.class.polymorphic_name` is the correct value for `describable_type`.
+
+---
+
+### Task 1: `Services::DescriptionColumnBackfill`
+
+**Files:**
+- Create: `web-app/app/lib/services/description_column_backfill.rb`
+- Create: `web-app/test/lib/services/description_column_backfill_test.rb`
+
+**Interfaces:**
+- Consumes: `Description` (enums `kind`/`rank` unprefixed, `source`/`license` prefixed), and the unique index `index_descriptions_on_describable_and_key`.
+- Produces: `Services::DescriptionColumnBackfill.call -> Result`, where `Result` responds to `success?`, `data`, `errors`. `data` is `{counts: {"Games::Game" => 1602, ...}, total: 11382}` keyed by model name. Task 2's rake task prints this.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/lib/services/description_column_backfill_test.rb`:
+
+```ruby
+require "test_helper"
+
+module Services
+  class DescriptionColumnBackfillTest < ActiveSupport::TestCase
+    test "creates a description row per populated column with the right source" do
+      games_games(:tears_of_the_kingdom).update_column(:description, "A sequel across sky islands.")
+      games_companies(:capcom).update_column(:description, "A Japanese game developer and publisher.")
+      games_series(:resident_evil).update_column(:description, "A survival horror series.")
+      music_albums(:animals).update_column(:description, "A concept album loosely based on Animal Farm.")
+      music_artists(:roger_waters).update_column(:description, "English songwriter and bassist.")
+
+      Services::DescriptionColumnBackfill.call
+
+      assert_equal "igdb", Description.find_by(describable: games_games(:tears_of_the_kingdom)).source
+      assert_equal "igdb", Description.find_by(describable: games_companies(:capcom)).source
+      assert_equal "manual", Description.find_by(describable: games_series(:resident_evil)).source
+      assert_equal "ai_generated", Description.find_by(describable: music_albums(:animals)).source
+      assert_equal "ai_generated", Description.find_by(describable: music_artists(:roger_waters)).source
+    end
+
+    test "writes summary kind, en locale, normal rank and no source_name" do
+      music_artists(:roger_waters).update_column(:description, "English songwriter and bassist.")
+
+      Services::DescriptionColumnBackfill.call
+
+      row = Description.find_by(describable: music_artists(:roger_waters))
+      assert_equal "summary", row.kind
+      assert_equal "en", row.locale
+      assert_equal "normal", row.rank
+      assert_nil row.source_name
+      assert_nil row.license
+      assert_nil row.retrieved_at
+      assert_equal "English songwriter and bassist.", row.content
+    end
+
+    test "skips nil, empty and whitespace-only descriptions" do
+      music_artists(:roger_waters).update_column(:description, "")
+      music_artists(:david_gilmour).update_column(:description, "   ")
+      music_albums(:animals).update_column(:description, nil)
+
+      Services::DescriptionColumnBackfill.call
+
+      assert_nil Description.find_by(describable: music_artists(:roger_waters))
+      assert_nil Description.find_by(describable: music_artists(:david_gilmour))
+      assert_nil Description.find_by(describable: music_albums(:animals))
+    end
+
+    test "leaves an existing description row untouched" do
+      existing = descriptions(:dark_side_ai)
+      music_albums(:dark_side_of_the_moon).update_column(:description, "column text that must not win")
+
+      Services::DescriptionColumnBackfill.call
+
+      existing.reload
+      assert_equal "preferred", existing.rank
+      assert_not_equal "column text that must not win", existing.content
+    end
+
+    test "is idempotent" do
+      music_artists(:roger_waters).update_column(:description, "English songwriter and bassist.")
+      Services::DescriptionColumnBackfill.call
+      after_first = Description.count
+
+      assert_no_difference "Description.count" do
+        Services::DescriptionColumnBackfill.call
+      end
+      assert_equal after_first, Description.count
+    end
+
+    test "does not create rows for books" do
+      before = Description.where(describable_type: ["Books::Book", "Books::Author"]).count
+
+      Services::DescriptionColumnBackfill.call
+
+      assert_equal before, Description.where(describable_type: ["Books::Book", "Books::Author"]).count
+    end
+
+    test "returns a successful result with per-model counts and a total" do
+      games_games(:tears_of_the_kingdom).update_column(:description, "A sequel across sky islands.")
+      music_artists(:roger_waters).update_column(:description, "English songwriter and bassist.")
+
+      result = Services::DescriptionColumnBackfill.call
+
+      assert result.success?
+      assert_empty result.errors
+      assert_equal Games::Game.where.not(description: [nil, ""]).count,
+        result.data[:counts]["Games::Game"]
+      assert_equal Music::Artist.where.not(description: [nil, ""]).count,
+        result.data[:counts]["Music::Artist"]
+      assert_equal result.data[:counts].values.sum, result.data[:total]
+    end
+  end
+end
+```
+
+`update_column` writes straight to the database, skipping validations and callbacks, so these fixtures are modified without side effects and the change rolls back with the test transaction.
+
+Note that `music/albums.yml` and `music/artists.yml` already set `description` on six fixtures each, so the backfill legitimately creates rows for them on every run. That is why the blank-skipping test asserts per-record `nil` rather than a global `Description.count`, and why the counts test derives its expectation from the database instead of hardcoding a number. The games fixtures set no descriptions.
+
+The fourth test is the one that matters most: `descriptions(:dark_side_ai)` is a `preferred` row on `dark_side_of_the_moon`, so it pins the invariant that a re-run cannot demote or overwrite an editorial choice. It fails if anyone swaps `insert_all` for `upsert_all`.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `bin/rails test test/lib/services/description_column_backfill_test.rb`
+Expected: FAIL with `NameError: uninitialized constant Services::DescriptionColumnBackfill`.
+
+- [ ] **Step 3: Write the service**
+
+Create `app/lib/services/description_column_backfill.rb`:
+
+```ruby
+module Services
+  class DescriptionColumnBackfill
+    Result = Struct.new(:success?, :data, :errors, keyword_init: true)
+
+    INSERT_BATCH = 1000
+
+    SOURCE_BY_MODEL = {
+      "Games::Game" => :igdb,
+      "Games::Company" => :igdb,
+      "Games::Series" => :manual,
+      "Music::Album" => :ai_generated,
+      "Music::Artist" => :ai_generated
+    }.freeze
+
+    def self.call
+      new.call
+    end
+
+    def call
+      counts = SOURCE_BY_MODEL.each_with_object({}) do |(model_name, source), acc|
+        acc[model_name] = backfill(model_name.constantize, source)
+      end
+      Result.new(success?: true, data: {counts: counts, total: counts.values.sum}, errors: [])
+    rescue => e
+      Result.new(success?: false, data: {}, errors: [e.message])
+    end
+
+    private
+
+    def backfill(model, source)
+      written = 0
+      buffer = []
+
+      model.where.not(description: [nil, ""]).find_each(batch_size: INSERT_BATCH) do |record|
+        content = record.description.presence
+        next if content.nil?
+
+        buffer << row_for(record, source, content)
+        if buffer.size >= INSERT_BATCH
+          written += flush(buffer)
+          buffer = []
+        end
+      end
+
+      written += flush(buffer) if buffer.any?
+      written
+    end
+
+    def row_for(record, source, content)
+      {
+        describable_type: record.class.polymorphic_name,
+        describable_id: record.id,
+        kind: :summary,
+        locale: "en",
+        source: source,
+        content: content,
+        rank: :normal
+      }
+    end
+
+    # insert_all, not upsert_all: ON CONFLICT DO NOTHING leaves an existing row alone.
+    # upsert_all would reset a human's rank: :preferred back to :normal and overwrite
+    # edited content on every re-run.
+    def flush(rows)
+      Description.insert_all(rows, unique_by: :index_descriptions_on_describable_and_key)
+      rows.size
+    end
+  end
+end
+```
+
+`.presence` catches whitespace-only values that the `where.not` cannot; the `where.not` merely avoids loading obvious blanks. Both are needed — 41 rows in production data are empty strings, and `descriptions_content_not_blank` would reject the whole batch if they got through.
+
+Note `flush` returns `rows.size`, which counts rows *offered*, not rows actually inserted — a row skipped by ON CONFLICT still counts. That is intentional: the number is a progress figure for the rake output, and the authoritative check is `Description.count` in Task 2.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `bin/rails test test/lib/services/description_column_backfill_test.rb`
+Expected: PASS, 7 tests, 0 failures.
+
+- [ ] **Step 5: Lint and run the full suite**
+
+```bash
+bundle exec standardrb --fix app/lib/services/description_column_backfill.rb test/lib/services/description_column_backfill_test.rb
+bundle exec standardrb
+bin/rails test
+```
+
+Expected: standardrb clean, suite green with no new failures.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/lib/services/description_column_backfill.rb test/lib/services/description_column_backfill_test.rb
+git commit -m "Add Services::DescriptionColumnBackfill
+
+Lifts the five in-app games/music description columns onto Description rows.
+insert_all rather than upsert_all: a re-run must not reset a human's
+rank: :preferred or overwrite edited content, which upsert_all does.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Rake task and the dev run
+
+**Files:**
+- Modify: `web-app/lib/tasks/data_migration.rake`
+
+**Interfaces:**
+- Consumes: `Services::DescriptionColumnBackfill.call -> Result` from Task 1.
+- Produces: `bin/rails data_migration:description_columns`.
+
+- [ ] **Step 1: Add the rake task**
+
+In `lib/tasks/data_migration.rake`, add immediately before the final `task all:` line (this task is standalone and must **not** join `:all`, which is the legacy books Phase-1 chain):
+
+```ruby
+  desc "Backfill Description rows from the in-app games/music description columns (reads the current DB, no legacy connection)"
+  task description_columns: :environment do
+    pp Services::DescriptionColumnBackfill.call
+  end
+```
+
+- [ ] **Step 2: Verify the task is registered**
+
+Run: `bin/rails -T data_migration | grep description_columns`
+Expected: one line describing the task.
+
+- [ ] **Step 3: Snapshot the development database**
+
+```bash
+bin/snapshot-dev-db.sh --label pre-b1-description-columns
+```
+
+This is a data-writing run against a database whose books content exists nowhere else. The snapshot turns any mistake into a ~1 minute restore.
+
+- [ ] **Step 4: Record the pre-run state**
+
+```bash
+bin/rails runner 'puts "Description.count before: #{Description.count}"'
+```
+
+Expected: `0`.
+
+- [ ] **Step 5: Run the backfill**
+
+Run: `bin/rails data_migration:description_columns`
+
+Expected output — a `Result` with `success?: true` and:
+
+```
+counts: {"Games::Game"=>1602, "Games::Company"=>658, "Games::Series"=>5,
+         "Music::Album"=>3649, "Music::Artist"=>5468}
+total: 11382
+```
+
+- [ ] **Step 6: Verify the result against the database**
+
+```bash
+bin/rails runner '
+puts "total: #{Description.count} (expected 11382)"
+puts Description.group(:describable_type).count.inspect
+puts "non-summary kinds:  #{Description.where.not(kind: :summary).count} (expected 0)"
+puts "non-en locales:     #{Description.where.not(locale: "en").count} (expected 0)"
+puts "non-normal ranks:   #{Description.where.not(rank: :normal).count} (expected 0)"
+puts "with source_name:   #{Description.where.not(source_name: nil).count} (expected 0)"
+puts "blank content:      #{Description.where("btrim(content) = ?", "").count} (expected 0)"
+puts "books rows:         #{Description.where(describable_type: ["Books::Book", "Books::Author"]).count} (expected 0)"
+'
+```
+
+Expected: total 11382; per-type `{"Music::Artist"=>5468, "Music::Album"=>3649, "Games::Game"=>1602, "Games::Company"=>658, "Games::Series"=>5}`; every other line 0.
+
+If the total is short, the likely cause is the `.presence` guard behaving differently than expected on the 41 empty-string rows — report the actual counts rather than adjusting the expectation.
+
+- [ ] **Step 7: Verify idempotency and non-clobbering on real data**
+
+```bash
+bin/rails runner '
+d = Description.find_by(describable_type: "Music::Album")
+original_content = d.content
+original_rank = d.rank
+d.update!(rank: :preferred, content: "editorial override")
+before = Description.count
+
+Services::DescriptionColumnBackfill.call
+
+d.reload
+puts "count stable:   #{Description.count == before} (#{before})"
+puts "rank preserved: #{d.rank == "preferred"}"
+puts "content kept:   #{d.content == "editorial override"}"
+
+d.update!(rank: original_rank, content: original_content)
+puts "restored:       rank=#{d.reload.rank} content_matches=#{d.content == original_content}"
+'
+```
+
+Expected: the three checks `true`, then `restored: rank=normal content_matches=true`. This is the real-data version of the fourth unit test and the reason `insert_all` was chosen. Both the rank *and* the content must be restored — an earlier draft of this step restored only the rank and would have left `"editorial override"` in the development database.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add lib/tasks/data_migration.rake
+git commit -m "Add data_migration:description_columns rake task
+
+Standalone -- deliberately not part of data_migration:all, which is the
+legacy books Phase-1 chain. This reads the current database.
+
+Dev run verified: 11,382 rows, idempotent, existing rows untouched.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Done when
+
+- `bin/rails test` passes and `bundle exec standardrb` is clean
+- `bin/rails data_migration:description_columns` reports `total: 11382`
+- `Description.count` is 11,382 in development, split
+  `{Music::Artist 5468, Music::Album 3649, Games::Game 1602, Games::Company 658, Games::Series 5}`
+- A second run changes nothing and preserves an edited row's rank and content
+- No schema change, no page behaviour change — the eleven `description` columns are still authoritative
+
+## Not in this increment
+
+b2 adds `BookDescriptionMigrator` (139,851 rows) and `AuthorDescriptionMigrator` (46,784), both of which need the `legacy_books` connection, plus the books/authors safety net that has to run after them. (c) cuts the write paths over. (d) cuts the read paths over. (e) drops the eleven columns.
+
+**Carry to b2:** the same `upsert_all` clobber applies there. b2 intentionally writes `rank: :preferred` for the 2,139 legacy `use_description` books, so it cannot simply switch to `insert_all` — decide its re-run semantics deliberately when planning it.

--- a/docs/superpowers/specs/2026-07-27-descriptions-subsystem-design.md
+++ b/docs/superpowers/specs/2026-07-27-descriptions-subsystem-design.md
@@ -201,7 +201,7 @@ The per-row `license` column makes the encumbered rows queryable for the first t
 | D4 | `rank` enum `{deprecated: -1, normal: 0, preferred: 1}` — not a `primary` boolean | Wikidata's model. `deprecated` lets a known-bad row stay for idempotent re-import while being permanently excluded from display; a boolean cannot express that. |
 | D5 | Importers may only create/update the row matching their own `source`, and may **never** write `rank`. Only *deliberate selection operations* set `preferred` — and those are usually programmatic, not per-record clicks. | Makes the Jellyfin lock-flag failure mode structurally impossible. Replaces `pinned_at`/`pinned_by` from the research recommendation — with this invariant, `rank: :preferred` already *is* the record of the selection. **Corrected 2026-07-28:** an earlier wording said "only humans set `preferred`", which misdescribes the real workflow. On the legacy site the owner's main use of `use_description` was a **bulk button that flipped every book on a list to Goodreads**, because the books were that year's releases and the AI did not know them. The distinction that matters is not human-vs-machine but *syncing a source* (never touches `rank`) vs *choosing which source wins* (may). |
 | D14 | The DB enforces at most one `preferred` row per `(describable, kind, locale)` — partial unique index `WHERE rank = 1` | D5 is otherwise only a convention, and the operations that set `preferred` are bulk writes, which is exactly where a convention breaks silently. A bulk switch that sets new `preferred` rows without clearing the old ones would leave every affected record double-flagged, with no error and no symptom — the resolver would quietly fall back to source priority, the very thing `preferred` exists to override. Added while the table was empty; after the backfill it would cost a 198k-row validation pass. Consequence: increment (c)'s `set_preferred` must demote-then-promote inside a transaction, so it cannot mirror `Image#unset_other_primary_images` (an `after_save` that promotes first). |
-| D15 | `content` carries a DB check constraint `length(btrim(content)) > 0`, not just `validates :content, presence: true` | `null: false` does not stop `""`, and the backfill's `upsert_all` bypasses validations. Verified empirically: a blank-content row was accepted under `upsert_all`. A `build_rows` that tests truthiness instead of `.presence` would land empty descriptions in production *and still pass the row-count verification*. **Known gap:** single-argument `btrim` trims ASCII spaces only, so `"\t\n"` passes the DB check while being `.blank?` in Ruby. Not load-bearing — the failure mode being guarded produces `""` — but worth widening if increment (b) touches this migration anyway. |
+| D15 | `content` carries a DB check constraint `length(btrim(content)) > 0`, not just `validates :content, presence: true` | `null: false` does not stop `""`, and the backfill's `upsert_all` bypasses validations. Verified empirically: a blank-content row was accepted under `upsert_all`. A `build_rows` that tests truthiness instead of `.presence` would land empty descriptions in production *and still pass the row-count verification*. **Known gap:** single-argument `btrim` trims ASCII spaces only, so `"\t\n"` passes the DB check while being `.blank?` in Ruby. Not load-bearing — the failure mode being guarded produces `""` — but worth widening if increment (b2) touches this migration anyway. |
 | D6 | `license` and `source_url` per row; `retrieved_at` per row | Wikidata CC0 vs Wikipedia CC BY-SA arrive from the same integration. TMDB's 6-month cache limit needs `retrieved_at` the day we add a TMDB importer. |
 | D7 | Read through `primary_description`; drop the eleven columns | Owner's call over keeping the column as a maintained cache. One representation, nothing to drift. |
 | D8 | No `has_one :primary_description` — a `Descriptions::Resolver` over a loaded collection | The winner is computed, not flagged, so a `has_one` scope cannot express it. Entities carry 1–4 rows, so `includes(:descriptions)` is one extra query total. |
@@ -571,10 +571,26 @@ Gate before claiming done: `bin/rails test`, `bin/rails test:system`, `bundle ex
 | | Content | Behaviour change |
 |---|---|---|
 | a | `Description` model, schema, `Descriptions::Resolver`, `Describable`, tests | none |
-| b | Three backfill migrators + rake tasks + verification | none |
+| b1 | `Services::DescriptionColumnBackfill` — games + music, 11,382 rows | none |
+| b2 | `BookDescriptionMigrator` + `AuthorDescriptionMigrator` — 186,635 rows | none |
 | c | Write path: AI tasks, IGDB providers, admin panel, strip nine forms | yes |
 | d | Read path: five public + nine admin views, `AttributionComponent`, includes | yes |
 | e | Drop the eleven `description` columns | separate PR, post-production |
+
+**Why (b) splits.** The three backfills are not alike. `DescriptionColumnBackfill` reads the *current*
+database, needs no legacy connection, and moves 11,382 rows; the two legacy migrators need the
+`legacy_books` connection up and move 186,635. Running the small one first exercises the entire
+`upsert_all` path end to end — the `nulls_not_distinct` conflict target, enum-symbol serialisation, and
+all four constraints — against data that cannot fail for legacy-connection reasons, before 186k rows
+depend on that machinery. Nothing downstream is unblocked by the split ((c) and (d) span every domain
+at once), so this is purely de-risking.
+
+**b1 does not subclass `BulkUpsertMigrator`.** That base class and its parent `Migrator` both live under
+`Services::BooksMigration`, stream from a `legacy_model`, and wrap the load in
+`Services::BooksMigration.without_search_indexing`. `DescriptionColumnBackfill` has no legacy model and
+no search-indexing concern (`Description` is not `SearchIndexable`, and no `description` field is
+indexed). It is a standalone service that calls `upsert_all` directly, so b2's migrators remain the
+only `BulkUpsertMigrator` subclasses.
 
 ---
 

--- a/docs/superpowers/specs/2026-07-27-descriptions-subsystem-design.md
+++ b/docs/superpowers/specs/2026-07-27-descriptions-subsystem-design.md
@@ -201,7 +201,7 @@ The per-row `license` column makes the encumbered rows queryable for the first t
 | D4 | `rank` enum `{deprecated: -1, normal: 0, preferred: 1}` — not a `primary` boolean | Wikidata's model. `deprecated` lets a known-bad row stay for idempotent re-import while being permanently excluded from display; a boolean cannot express that. |
 | D5 | Importers may only create/update the row matching their own `source`, and may **never** write `rank`. Only *deliberate selection operations* set `preferred` — and those are usually programmatic, not per-record clicks. | Makes the Jellyfin lock-flag failure mode structurally impossible. Replaces `pinned_at`/`pinned_by` from the research recommendation — with this invariant, `rank: :preferred` already *is* the record of the selection. **Corrected 2026-07-28:** an earlier wording said "only humans set `preferred`", which misdescribes the real workflow. On the legacy site the owner's main use of `use_description` was a **bulk button that flipped every book on a list to Goodreads**, because the books were that year's releases and the AI did not know them. The distinction that matters is not human-vs-machine but *syncing a source* (never touches `rank`) vs *choosing which source wins* (may). |
 | D14 | The DB enforces at most one `preferred` row per `(describable, kind, locale)` — partial unique index `WHERE rank = 1` | D5 is otherwise only a convention, and the operations that set `preferred` are bulk writes, which is exactly where a convention breaks silently. A bulk switch that sets new `preferred` rows without clearing the old ones would leave every affected record double-flagged, with no error and no symptom — the resolver would quietly fall back to source priority, the very thing `preferred` exists to override. Added while the table was empty; after the backfill it would cost a 198k-row validation pass. Consequence: increment (c)'s `set_preferred` must demote-then-promote inside a transaction, so it cannot mirror `Image#unset_other_primary_images` (an `after_save` that promotes first). |
-| D15 | `content` carries a DB check constraint `length(btrim(content)) > 0`, not just `validates :content, presence: true` | `null: false` does not stop `""`, and the backfill's `upsert_all` bypasses validations. Verified empirically: a blank-content row was accepted under `upsert_all`. A `build_rows` that tests truthiness instead of `.presence` would land empty descriptions in production *and still pass the row-count verification*. **Known gap:** single-argument `btrim` trims ASCII spaces only, so `"\t\n"` passes the DB check while being `.blank?` in Ruby. Not load-bearing — the failure mode being guarded produces `""` — but worth widening if increment (b2) touches this migration anyway. |
+| D15 | `content` carries a DB check constraint `length(btrim(content)) > 0`, not just `validates :content, presence: true` | `null: false` does not stop `""`, and b2's migrators' `upsert_all` bypasses validations. Verified empirically: a blank-content row was accepted under `upsert_all`. A `build_rows` that tests truthiness instead of `.presence` would land empty descriptions in production *and still pass the row-count verification*. **Known gap:** single-argument `btrim` trims ASCII spaces only, so `"\t\n"` passes the DB check while being `.blank?` in Ruby. Not load-bearing — the failure mode being guarded produces `""` — but worth widening if increment (b2) touches this migration anyway. |
 | D6 | `license` and `source_url` per row; `retrieved_at` per row | Wikidata CC0 vs Wikipedia CC BY-SA arrive from the same integration. TMDB's 6-month cache limit needs `retrieved_at` the day we add a TMDB importer. |
 | D7 | Read through `primary_description`; drop the eleven columns | Owner's call over keeping the column as a maintained cache. One representation, nothing to drift. |
 | D8 | No `has_one :primary_description` — a `Descriptions::Resolver` over a loaded collection | The winner is computed, not flagged, so a `has_one` scope cannot express it. Entities carry 1–4 rows, so `includes(:descriptions)` is one extra query total. |
@@ -264,7 +264,8 @@ an editor switching a row from `:other` to a named source through a form that do
 (`source_other? ? source_name : source.humanize`). A publisher-specific label is expressible as
 `:other` + `"Penguin Classics"`, so nothing is lost.
 
-Two further DB-level guards, added because `upsert_all` bypasses every model validation (D14, D15):
+Two further DB-level guards, added because both `insert_all` (b1) and `upsert_all` (b2) bypass every
+model validation (D14, D15):
 
 ```ruby
 add_check_constraint :descriptions, "length(btrim(content)) > 0",
@@ -425,7 +426,17 @@ is the correct semantic.
 **Open question for b2:** the same clobber applies to `BookDescriptionMigrator` and
 `AuthorDescriptionMigrator`, which inherit `BulkUpsertMigrator`'s `upsert_all`. Unlike b1 they
 *intentionally* write `rank: :preferred` for the 2,139 legacy `use_description` books, so they cannot
-simply switch. Decide their re-run semantics deliberately when planning b2.
+simply switch. Compounding this, `upsert_all`'s `ON CONFLICT DO UPDATE` also risks
+`index_descriptions_one_preferred_per_key` (D14): after increment (c) ships and an admin flips a book's
+preferred row from `goodreads` to `ai_generated`, a b2 re-run emits `(ai_generated, rank: normal)` and
+`(goodreads, rank: preferred)` for that book in one statement. If the `goodreads` row is processed
+first, the partial index is momentarily double-occupied and PostgreSQL raises `PG::UniqueViolation`,
+which `ON CONFLICT` cannot absorb because the arbiter is the *other* index — aborting the whole
+1000-row batch. Whether it fires depends on `build_rows` emission order. **Recommended resolution:**
+`insert_all` for all rows exactly as b1 does, then a separate `finalize` pass setting `preferred` only
+where no `preferred` row already exists for that `(describable, kind, locale)`. That keeps b1 and b2
+consistent and makes the rank write a deliberate single-purpose statement rather than a side effect of
+a 186k-row upsert. Decide their re-run semantics deliberately when planning b2.
 
 `rank: :normal`, not `:preferred` — corrected 2026-07-28. Every entity this backfill touches receives
 exactly **one** row (games get only `:igdb`, music only `:ai_generated`, `games_series` only `:manual`,
@@ -550,9 +561,10 @@ then save is a race. The unique index rejects the loser; rescue `ActiveRecord::R
 retry once against the reloaded row. Cheaper than the per-book advisory lock `BookImageMigrator` needed,
 because here the index is the guard.
 
-**`upsert_all` bypasses validations** in the backfill, so the unique index and the CHECK constraint are
-load-bearing rather than belt-and-braces — the same landmine as `ListPenaltyMigrator`'s static-guard in
-PR #165, where the guard had to move into `build_rows`. Rows are validated at build time before upsert.
+**`upsert_all` bypasses validations in b2's migrators** (`insert_all` does the same for b1), so the
+unique index and the CHECK constraint are load-bearing rather than belt-and-braces — the same landmine
+as `ListPenaltyMigrator`'s static-guard in PR #165, where the guard had to move into `build_rows`. Rows
+are validated at build time before upsert.
 
 **Importers writing `rank`** cannot be prevented by the database. Enforced by not exposing `rank` on the
 provider/task API surface, plus a test asserting an AI regeneration leaves a `preferred` sibling
@@ -592,18 +604,22 @@ Gate before claiming done: `bin/rails test`, `bin/rails test:system`, `bundle ex
 | e | Drop the eleven `description` columns | separate PR, post-production |
 
 **Why (b) splits.** The three backfills are not alike. `DescriptionColumnBackfill` reads the *current*
-database, needs no legacy connection, and moves 11,382 rows; the two legacy migrators need the
-`legacy_books` connection up and move 186,635. Running the small one first exercises the entire
-`upsert_all` path end to end — the `nulls_not_distinct` conflict target, enum-symbol serialisation, and
-all four constraints — against data that cannot fail for legacy-connection reasons, before 186k rows
-depend on that machinery. Nothing downstream is unblocked by the split ((c) and (d) span every domain
-at once), so this is purely de-risking.
+database, needs no legacy connection, moves 11,382 rows, and writes with `insert_all`; the two legacy
+migrators need the `legacy_books` connection up, move 186,635 rows, and write with `upsert_all`. Running
+the small one first exercises arbiter inference against the `NULLS NOT DISTINCT` index (proven by an
+idempotent second run over rows whose `source_name` is NULL), enum-symbol serialisation, and the two
+check constraints — against data that cannot fail for legacy-connection reasons, before 186k rows depend
+on that machinery. It does **not** exercise `ON CONFLICT DO UPDATE` semantics, the intra-batch
+`PG::CardinalityViolation` risk, or `index_descriptions_one_preferred_per_key`: b1 writes only
+`rank: :normal` rows, so that partial index can never fire, and b2 will hit it on its first run. Nothing
+downstream is unblocked by the split ((c) and (d) span every domain at once), so this is purely
+de-risking.
 
 **b1 does not subclass `BulkUpsertMigrator`.** That base class and its parent `Migrator` both live under
 `Services::BooksMigration`, stream from a `legacy_model`, and wrap the load in
 `Services::BooksMigration.without_search_indexing`. `DescriptionColumnBackfill` has no legacy model and
 no search-indexing concern (`Description` is not `SearchIndexable`, and no `description` field is
-indexed). It is a standalone service that calls `upsert_all` directly, so b2's migrators remain the
+indexed). It is a standalone service that calls `insert_all` directly, so b2's migrators remain the
 only `BulkUpsertMigrator` subclasses.
 
 ---

--- a/docs/superpowers/specs/2026-07-27-descriptions-subsystem-design.md
+++ b/docs/superpowers/specs/2026-07-27-descriptions-subsystem-design.md
@@ -409,9 +409,23 @@ The in-app columns, all at `rank: :normal`:
 | `music_artists.description` | `:ai_generated` | 5,468 |
 | `games_series.description` | `:manual` | 5 |
 
-Plus a safety net: any `Books::Book` or `Books::Author` with a non-empty `description` and no row after
-the legacy backfill — the ~50 books and ~21 authors created in-app rather than migrated — gets a
-`:manual` row.
+**The books/authors safety net belongs to b2, not b1.** Any `Books::Book` or `Books::Author` with a
+non-empty `description` and no row *after the legacy backfill* — the ~50 books and ~21 authors created
+in-app rather than migrated — gets a `:manual` row. Since that is defined relative to the legacy
+migrators having run, it executes after them, in b2. b1 covers only the five games/music columns.
+
+**Use `insert_all`, not `upsert_all`.** Verified on PG 17: an `upsert_all` re-run resets a row's
+`rank: :preferred` back to `:normal` and overwrites edited content, because `ON CONFLICT DO UPDATE`
+writes every supplied column. That would silently undo every editorial choice on each run, directly
+violating D5. `insert_all` with the same `unique_by:` issues `ON CONFLICT DO NOTHING`, leaving existing
+rows alone; both cast enum symbols correctly. This is a one-time column lift — after increment (c) the
+importers write `Description` rows directly and the columns are no longer written — so skip-on-conflict
+is the correct semantic.
+
+**Open question for b2:** the same clobber applies to `BookDescriptionMigrator` and
+`AuthorDescriptionMigrator`, which inherit `BulkUpsertMigrator`'s `upsert_all`. Unlike b1 they
+*intentionally* write `rank: :preferred` for the 2,139 legacy `use_description` books, so they cannot
+simply switch. Decide their re-run semantics deliberately when planning b2.
 
 `rank: :normal`, not `:preferred` — corrected 2026-07-28. Every entity this backfill touches receives
 exactly **one** row (games get only `:igdb`, music only `:ai_generated`, `games_series` only `:manual`,

--- a/web-app/app/lib/services/description_column_backfill.rb
+++ b/web-app/app/lib/services/description_column_backfill.rb
@@ -1,0 +1,69 @@
+module Services
+  class DescriptionColumnBackfill
+    Result = Struct.new(:success?, :data, :errors, keyword_init: true)
+
+    INSERT_BATCH = 1000
+
+    SOURCE_BY_MODEL = {
+      "Games::Game" => :igdb,
+      "Games::Company" => :igdb,
+      "Games::Series" => :manual,
+      "Music::Album" => :ai_generated,
+      "Music::Artist" => :ai_generated
+    }.freeze
+
+    def self.call
+      new.call
+    end
+
+    def call
+      counts = SOURCE_BY_MODEL.each_with_object({}) do |(model_name, source), acc|
+        acc[model_name] = backfill(model_name.constantize, source)
+      end
+      Result.new(success?: true, data: {counts: counts, total: counts.values.sum}, errors: [])
+    rescue => e
+      Result.new(success?: false, data: {}, errors: [e.message])
+    end
+
+    private
+
+    def backfill(model, source)
+      written = 0
+      buffer = []
+
+      model.where.not(description: [nil, ""]).find_each(batch_size: INSERT_BATCH) do |record|
+        content = record.description.presence
+        next if content.nil?
+
+        buffer << row_for(record, source, content)
+        if buffer.size >= INSERT_BATCH
+          written += flush(buffer)
+          buffer = []
+        end
+      end
+
+      written += flush(buffer) if buffer.any?
+      written
+    end
+
+    def row_for(record, source, content)
+      {
+        describable_type: record.class.polymorphic_name,
+        describable_id: record.id,
+        kind: :summary,
+        locale: "en",
+        source: source,
+        content: content,
+        rank: :normal
+      }
+    end
+
+    # insert_all, not upsert_all: ON CONFLICT DO NOTHING leaves an existing row alone.
+    # upsert_all would reset a human's rank: :preferred back to :normal and overwrite
+    # edited content on every re-run.
+    def flush(rows)
+      Description.insert_all(rows, unique_by: :index_descriptions_on_describable_and_key)
+      rows.size
+    end
+  end
+end

--- a/web-app/app/lib/services/description_column_backfill.rb
+++ b/web-app/app/lib/services/description_column_backfill.rb
@@ -17,12 +17,15 @@ module Services
     end
 
     def call
+      current_model_name = nil
       counts = SOURCE_BY_MODEL.each_with_object({}) do |(model_name, source), acc|
+        current_model_name = model_name
         acc[model_name] = backfill(model_name.constantize, source)
       end
       Result.new(success?: true, data: {counts: counts, total: counts.values.sum}, errors: [])
     rescue => e
-      Result.new(success?: false, data: {}, errors: [e.message])
+      failed_model = current_model_name || "description column backfill"
+      Result.new(success?: false, data: {}, errors: ["#{failed_model} backfill failed: #{e.message}"])
     end
 
     private

--- a/web-app/lib/tasks/data_migration.rake
+++ b/web-app/lib/tasks/data_migration.rake
@@ -99,6 +99,11 @@ namespace :data_migration do
     pp Services::BooksMigration::BookImageMigrator.call
   end
 
+  desc "Backfill Description rows from the in-app games/music description columns (reads the current DB, no legacy connection)"
+  task description_columns: :environment do
+    pp Services::DescriptionColumnBackfill.call
+  end
+
   desc "Run all Phase-1 migrators in dependency order"
   task all: [:languages, :users, :authors, :books, :book_authors, :editions, :identifiers, :categories, :category_items, :external_links, :lists, :list_items, :ranking_configurations, :ranked_lists, :penalties, :list_penalties, :user_lists, :user_list_items]
 end

--- a/web-app/test/lib/services/description_column_backfill_test.rb
+++ b/web-app/test/lib/services/description_column_backfill_test.rb
@@ -68,6 +68,7 @@ module Services
     end
 
     test "does not create rows for books" do
+      books_books(:war_and_peace).update_column(:description, "in-app text that must not be backfilled")
       before = Description.where(describable_type: ["Books::Book", "Books::Author"]).count
 
       Services::DescriptionColumnBackfill.call

--- a/web-app/test/lib/services/description_column_backfill_test.rb
+++ b/web-app/test/lib/services/description_column_backfill_test.rb
@@ -1,0 +1,93 @@
+require "test_helper"
+
+module Services
+  class DescriptionColumnBackfillTest < ActiveSupport::TestCase
+    test "creates a description row per populated column with the right source" do
+      games_games(:tears_of_the_kingdom).update_column(:description, "A sequel across sky islands.")
+      games_companies(:capcom).update_column(:description, "A Japanese game developer and publisher.")
+      games_series(:resident_evil).update_column(:description, "A survival horror series.")
+      music_albums(:animals).update_column(:description, "A concept album loosely based on Animal Farm.")
+      music_artists(:roger_waters).update_column(:description, "English songwriter and bassist.")
+
+      Services::DescriptionColumnBackfill.call
+
+      assert_equal "igdb", Description.find_by(describable: games_games(:tears_of_the_kingdom)).source
+      assert_equal "igdb", Description.find_by(describable: games_companies(:capcom)).source
+      assert_equal "manual", Description.find_by(describable: games_series(:resident_evil)).source
+      assert_equal "ai_generated", Description.find_by(describable: music_albums(:animals)).source
+      assert_equal "ai_generated", Description.find_by(describable: music_artists(:roger_waters)).source
+    end
+
+    test "writes summary kind, en locale, normal rank and no source_name" do
+      music_artists(:roger_waters).update_column(:description, "English songwriter and bassist.")
+
+      Services::DescriptionColumnBackfill.call
+
+      row = Description.find_by(describable: music_artists(:roger_waters))
+      assert_equal "summary", row.kind
+      assert_equal "en", row.locale
+      assert_equal "normal", row.rank
+      assert_nil row.source_name
+      assert_nil row.license
+      assert_nil row.retrieved_at
+      assert_equal "English songwriter and bassist.", row.content
+    end
+
+    test "skips nil, empty and whitespace-only descriptions" do
+      music_artists(:roger_waters).update_column(:description, "")
+      music_artists(:david_gilmour).update_column(:description, "   ")
+      music_albums(:animals).update_column(:description, nil)
+
+      Services::DescriptionColumnBackfill.call
+
+      assert_nil Description.find_by(describable: music_artists(:roger_waters))
+      assert_nil Description.find_by(describable: music_artists(:david_gilmour))
+      assert_nil Description.find_by(describable: music_albums(:animals))
+    end
+
+    test "leaves an existing description row untouched" do
+      existing = descriptions(:dark_side_ai)
+      music_albums(:dark_side_of_the_moon).update_column(:description, "column text that must not win")
+
+      Services::DescriptionColumnBackfill.call
+
+      existing.reload
+      assert_equal "preferred", existing.rank
+      assert_not_equal "column text that must not win", existing.content
+    end
+
+    test "is idempotent" do
+      music_artists(:roger_waters).update_column(:description, "English songwriter and bassist.")
+      Services::DescriptionColumnBackfill.call
+      after_first = Description.count
+
+      assert_no_difference "Description.count" do
+        Services::DescriptionColumnBackfill.call
+      end
+      assert_equal after_first, Description.count
+    end
+
+    test "does not create rows for books" do
+      before = Description.where(describable_type: ["Books::Book", "Books::Author"]).count
+
+      Services::DescriptionColumnBackfill.call
+
+      assert_equal before, Description.where(describable_type: ["Books::Book", "Books::Author"]).count
+    end
+
+    test "returns a successful result with per-model counts and a total" do
+      games_games(:tears_of_the_kingdom).update_column(:description, "A sequel across sky islands.")
+      music_artists(:roger_waters).update_column(:description, "English songwriter and bassist.")
+
+      result = Services::DescriptionColumnBackfill.call
+
+      assert result.success?
+      assert_empty result.errors
+      assert_equal ::Games::Game.where.not(description: [nil, ""]).count,
+        result.data[:counts]["Games::Game"]
+      assert_equal ::Music::Artist.where.not(description: [nil, ""]).count,
+        result.data[:counts]["Music::Artist"]
+      assert_equal result.data[:counts].values.sum, result.data[:total]
+    end
+  end
+end


### PR DESCRIPTION
Increment (b1) of the descriptions subsystem. Populates the `Description` table that increment (a) (#180) shipped empty, by lifting the five in-app games/music `description` columns onto rows — **11,382 of them**.

The columns are untouched and remain authoritative. Nothing reads `Description` yet, so no page changes.

Design: `docs/superpowers/specs/2026-07-27-descriptions-subsystem-design.md`
Plan: `docs/superpowers/plans/2026-07-29-descriptions-b1-column-backfill.md`

## Why (b) split into b1 and b2

The three backfills aren't alike. This one reads the **current** database, needs no legacy connection, and moves 11,382 rows; b2's two migrators need `legacy_books` up and move 186,635. Running the small one first exercises the machinery against data that can't fail for legacy-connection reasons.

The spec now records precisely what that did and didn't prove — arbiter inference against the `NULLS NOT DISTINCT` index, enum-symbol serialisation and both check constraints **were** exercised; `ON CONFLICT DO UPDATE`, the intra-batch `CardinalityViolation` risk, and `index_descriptions_one_preferred_per_key` **were not**, since b1 writes only `rank: :normal`.

## `insert_all`, not `upsert_all`

The spec originally called for `upsert_all`. Probing it on PG 17 showed why that's wrong:

```
after insert_all re-run -> rank="preferred" content="human edited"
after upsert_all re-run -> rank="normal"    content="first"
```

`ON CONFLICT DO UPDATE` writes every supplied column, so **every re-run would reset each row's `rank: :preferred` to `:normal` and overwrite edited content** — silently undoing editorial choices, against D5's "importers may never write `rank`". `insert_all` issues `ON CONFLICT DO NOTHING`.

A test pinned to the `dark_side_ai` fixture (a `preferred` row on an album whose fixture also sets the column, so the conflict is real) goes red on both assertions if anyone swaps it back.

## The `.presence` guard is load-bearing

41 of the source rows are empty strings — Games::Company 15, Games::Series 10, Music::Album 13, Music::Artist 3. A `build_rows` testing truthiness would offer 41 blank-content rows and `descriptions_content_not_blank` would reject the whole batch. That constraint, added on review feedback in #180, earns its place on run one.

## Dev run — executed and independently verified

Snapshot taken first (`dev-20260729-080807-pre-b1-description-columns.dump`, confirmed to predate the write).

| | rows |
|---|---|
| `Music::Artist` | 5,468 |
| `Music::Album` | 3,649 |
| `Games::Game` | 1,602 |
| `Games::Company` | 658 |
| `Games::Series` | 5 |
| **total** | **11,382** |

Zero rows with a non-`summary` kind, non-`en` locale, non-`normal` rank, a `source_name`, blank content, or a `Books::*` type. Second run inserted nothing and left an edited row's rank *and* content intact. A reviewer reproduced all of it read-only, cross-checked each model against its source column, and sampled 200 albums for content fidelity.

## Production

**Increment (d) flips five public views to read `primary_description`.** If `data_migration:description_columns` hasn't run in production before (d) deploys, every games and music page silently loses its description. The plan now carries a Production-run section stating that dependency, with an **invariant-based** verification rather than the dev-specific `11382` — production will legitimately differ, and an operator checking against that constant would read a correct run as a failure.

## Testing

`bin/rails test` — 4904 runs, 13106 assertions, 0 failures, 0 errors, 0 skips. `bundle exec standardrb` clean.

## Not in this PR

b2 backfills 186,635 rows from the legacy database. Its open question is now documented in full: its migrators write `rank: :preferred` for 2,139 books via bulk upsert, which can momentarily double-occupy `index_descriptions_one_preferred_per_key` and raise a `PG::UniqueViolation` that `ON CONFLICT` cannot absorb — because the arbiter is the *other* index. Recommended resolution recorded in the spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)