### PR TITLE
Descriptions (c1): write paths off the description column

### DIFF
--- a/docs/superpowers/plans/2026-07-30-descriptions-c1-write-paths.md
+++ b/docs/superpowers/plans/2026-07-30-descriptions-c1-write-paths.md
@@ -1,0 +1,546 @@
+# Descriptions (c1) — Write Paths Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop the four importer/AI write sites from clobbering the `description` column, and have each write its own source's `Description` row instead.
+
+**Architecture:** One helper, `Describable#assign_description`, does the lookup-or-build and assigns content without saving. The two music AI tasks save the returned row directly (their parent is always persisted); the two IGDB providers assign only and let `ImporterBase#run_providers_with_saving`'s `item.save!` cascade through a newly-added `autosave: true`. No UI, no schema change, no data migration.
+
+**Tech Stack:** Rails 8.1, PostgreSQL 17, Minitest + Mocha + fixtures, `standardrb`.
+
+**Spec:** `docs/superpowers/specs/2026-07-29-descriptions-c-write-paths-admin-design.md` (increment c1 — decisions C1, C2, C2a). Parent spec: `docs/superpowers/specs/2026-07-27-descriptions-subsystem-design.md` (D5).
+
+---
+
+## Global Constraints
+
+- Run **every** Rails command from `web-app/`. Docs live at the project root in `docs/`, not `web-app/docs/`.
+- Lint with `bundle exec standardrb` (`--fix` autocorrects). **Never** `bin/rubocop`. **Never** run brakeman.
+- **The development database is not disposable.** The books data exists only in dev and takes hours to rebuild. Never run `db:drop`, `db:reset`, `db:schema:load`, `create_fixtures`, or any bulk mutation. **This increment needs no migration and no data run — tests only.**
+- **No code comments inside method bodies.** Short method-level comments explaining *why* are fine and match the surrounding code.
+- **`assign_description` must never assign `rank`** (D5). Only deliberate selection operations set rank, and none of them live in this increment.
+- **Use `detect`, never `find_or_initialize_by`** (C2a). This is the single most important constraint in the plan — see the verified behaviour table below.
+- `.presence`/`.blank?`, never truthiness, on content.
+- Do not change any public view or admin form in this increment. Increment c3 strips the forms.
+
+### Verified behaviour (probed on PG 17 / Rails 8.1, 2026-07-30 — do not re-derive)
+
+| Case | Result |
+|---|---|
+| `find_or_initialize_by` + `parent.save!`, persisted parent, existing row | **Silently does not update.** `find_by` issues a query and returns an instance that is **not in the association's target**; `autosave` only iterates the target. |
+| ...same, with the association pre-loaded first | **Still does not update** — `find_by` issues a fresh query regardless. |
+| `detect` over the association + `parent.save!` | **Updates correctly** — `detect` returns the target instance. |
+| `detect` + `parent.save!` **without** `autosave: true` | **Does not update.** So `autosave: true` is genuinely required. |
+| `build` on a **new** parent, no `autosave` | Saves fine — new children always do. `autosave` matters only for the changed-existing case. |
+| `autosave: true` with an invalid **changed** child | Blocks the parent save with `ActiveRecord::RecordInvalid`. |
+
+### Fixture facts (checked — do not guess)
+
+- `test/fixtures/descriptions.yml` already attaches **`dark_side_ai`** to `music_albums(:dark_side_of_the_moon)` at `source: ai_generated, rank: preferred`, and **`botw_igdb`** to `games_games(:breath_of_the_wild)` at `source: igdb, rank: preferred`.
+- `music_albums(:animals)`, `music_artists(:roger_waters)`, `games_games(:tears_of_the_kingdom)` and `games_companies(:capcom)` have **no** description rows — use these when a test needs a clean parent.
+- `Services::Ai::Tasks::Music::AlbumDescriptionTaskTest#setup` uses `music_albums(:dark_side_of_the_moon)`; the artist test uses `music_artists(:pink_floyd)` — confirm before editing.
+- `DataImporters::Games::Game::Providers::IgdbTest#setup` uses `@game = ::Games::Game.new` — an **unsaved** record.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| Modify `web-app/app/models/concerns/describable.rb` | `autosave: true` + `assign_description` |
+| Modify `web-app/test/models/concerns/describable_test.rb` | Pin the helper and the autosave semantics |
+| Modify `web-app/app/lib/services/ai/tasks/music/album_description_task.rb` | Write the `:ai_generated` row |
+| Modify `web-app/app/lib/services/ai/tasks/music/artist_description_task.rb` | Same |
+| Modify `web-app/test/lib/services/ai/tasks/album_description_task_test.rb` | Assert the row, plus the clobber regression |
+| Modify `web-app/test/lib/services/ai/tasks/artist_description_task_test.rb` | Same |
+| Modify `web-app/app/lib/data_importers/games/game/providers/igdb.rb` | Write the `:igdb` row |
+| Modify `web-app/app/lib/data_importers/games/company/providers/igdb.rb` | Same |
+| Modify `web-app/test/lib/data_importers/games/game/providers/igdb_test.rb` | Assert the row + the re-import persistence test |
+| Modify `web-app/test/lib/data_importers/games/company/providers/igdb_test.rb` | Same |
+
+---
+
+### Task 1: `Describable#assign_description` + `autosave: true`
+
+**Files:**
+- Modify: `web-app/app/models/concerns/describable.rb`
+- Test: `web-app/test/models/concerns/describable_test.rb` (exists; append to `DescribableTest`)
+
+**Interfaces:**
+- Consumes: the `Description` model (`kind`, `locale`, `source`, `content`, `rank`, `retrieved_at`, `source_url`, `license`) and its natural-key unique index.
+- Produces: `Describable#assign_description(source:, content:, **attrs) → Description | nil`. Returns `nil` when `content` is blank. Returns an **unsaved-or-dirty** `Description` that is already in the parent's `descriptions` association target, with `content` and `retrieved_at` assigned plus any `**attrs` (e.g. `source_url:`, `license:`). It **never** assigns `rank`. Tasks 2 and 3 both call it.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append inside `DescribableTest` in `web-app/test/models/concerns/describable_test.rb`:
+
+```ruby
+  test "assign_description returns nil for blank content" do
+    album = music_albums(:animals)
+    [nil, "", "   ", "\t\n"].each do |blank|
+      assert_nil album.assign_description(source: :ai_generated, content: blank),
+        "expected #{blank.inspect} to be rejected"
+    end
+    assert_empty album.descriptions
+  end
+
+  test "assign_description builds a summary/en row at the given source" do
+    album = music_albums(:animals)
+
+    row = album.assign_description(source: :ai_generated, content: "A concept album about pigs.")
+
+    assert_equal "summary", row.kind
+    assert_equal "en", row.locale
+    assert_equal "ai_generated", row.source
+    assert_equal "A concept album about pigs.", row.content
+    assert_equal "normal", row.rank
+    assert_not_nil row.retrieved_at
+    assert row.new_record?
+  end
+
+  test "assign_description accepts extra attributes" do
+    album = music_albums(:animals)
+
+    row = album.assign_description(
+      source: :wikipedia,
+      content: "From Wikipedia.",
+      source_url: "https://en.wikipedia.org/wiki/Animals",
+      license: :cc_by_sa_4
+    )
+
+    assert_equal "https://en.wikipedia.org/wiki/Animals", row.source_url
+    assert_equal "cc_by_sa_4", row.license
+  end
+
+  # dark_side_ai is an existing ai_generated row on this album, at rank: preferred.
+  test "assign_description updates the existing row for that source instead of building a second" do
+    album = music_albums(:dark_side_of_the_moon)
+    existing = descriptions(:dark_side_ai)
+
+    assert_no_difference "Description.count" do
+      row = album.assign_description(source: :ai_generated, content: "Rewritten by the AI task.")
+      assert_equal existing.id, row.id
+      album.save!
+    end
+
+    assert_equal "Rewritten by the AI task.", existing.reload.content
+  end
+
+  # D5: importers may never write rank.
+  test "assign_description never changes rank" do
+    album = music_albums(:dark_side_of_the_moon)
+
+    album.assign_description(source: :ai_generated, content: "New text.")
+    album.save!
+
+    assert_equal "preferred", descriptions(:dark_side_ai).reload.rank
+  end
+
+  test "assign_description leaves a different source's row alone" do
+    album = music_albums(:dark_side_of_the_moon)
+
+    album.assign_description(source: :wikipedia, content: "A wikipedia row.")
+    album.save!
+
+    assert_equal 2, album.descriptions.reload.size
+    assert_equal "preferred", descriptions(:dark_side_ai).reload.rank
+  end
+
+  test "assign_description works on an unsaved parent and persists with it" do
+    book = Books::Book.new(title: "Assign Description On New Parent")
+
+    book.assign_description(source: :manual, content: "Written before the parent existed.")
+    book.save!
+
+    row = book.descriptions.reload.sole
+    assert_equal "manual", row.source
+    assert_equal "Written before the parent existed.", row.content
+  end
+
+  test "assign_description called twice on an unsaved parent updates one row, not two" do
+    book = Books::Book.new(title: "Assign Description Twice")
+
+    book.assign_description(source: :manual, content: "first")
+    book.assign_description(source: :manual, content: "second")
+    book.save!
+
+    assert_equal ["second"], book.descriptions.reload.pluck(:content)
+  end
+
+  # The autosave contract: without autosave: true this is a silent no-op.
+  test "saving the parent persists a changed existing description" do
+    album = music_albums(:animals)
+    album.descriptions.create!(kind: :summary, locale: "en", source: :ai_generated, content: "old")
+    album.reload
+
+    album.assign_description(source: :ai_generated, content: "new")
+    album.save!
+
+    assert_equal "new", album.descriptions.reload.sole.content
+  end
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `bin/rails test test/models/concerns/describable_test.rb`
+
+Expected: FAIL — `NoMethodError: undefined method 'assign_description'`.
+
+- [ ] **Step 3: Write the implementation**
+
+In `web-app/app/models/concerns/describable.rb`, add `autosave: true` to the association and the helper:
+
+```ruby
+module Describable
+  extend ActiveSupport::Concern
+
+  included do
+    has_many :descriptions, -> { order(:id) }, as: :describable, dependent: :destroy, autosave: true
+  end
+
+  def primary_description(kind: :summary, locale: "en")
+    Descriptions::Resolver.call(descriptions, kind: kind, locale: locale)
+  end
+
+  # Assigns without saving, so an importer can call this on a record that is not
+  # persisted yet and let the parent's save cascade. Looks the row up with detect
+  # rather than find_or_initialize_by: the latter queries and returns an instance
+  # that is not in the association target, which autosave never sees, so the write
+  # is silently lost. Never assigns rank (D5).
+  def assign_description(source:, content:, **attrs)
+    return nil if content.blank?
+
+    row = descriptions.detect { |d| d.kind == "summary" && d.locale == "en" && d.source == source.to_s } ||
+      descriptions.build(kind: :summary, locale: "en", source: source)
+    row.assign_attributes(content: content, retrieved_at: Time.current, **attrs)
+    row
+  end
+end
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `bin/rails test test/models/concerns/describable_test.rb`
+
+Expected: PASS, all tests green (the 8 pre-existing plus 9 new).
+
+- [ ] **Step 5: Run the broader model suite for autosave regressions**
+
+`autosave: true` is an app-wide association change across 11 models, so check more than the one file.
+
+Run: `bin/rails test test/models/ test/lib/services/description_column_backfill_test.rb`
+
+Expected: PASS, no failures. If anything fails, it is a real interaction with the new autosave — report it rather than working around it.
+
+- [ ] **Step 6: Lint and commit**
+
+```bash
+cd web-app && bundle exec standardrb --fix app/models/concerns/describable.rb test/models/concerns/describable_test.rb
+git add web-app/app/models/concerns/describable.rb web-app/test/models/concerns/describable_test.rb
+git commit -m "Add Describable#assign_description with autosave
+
+detect, not find_or_initialize_by: the latter returns an instance outside the
+association target, which autosave never sees, so the write is silently lost.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Music AI description tasks
+
+Both tasks currently call `parent.update!(description:)`, which overwrites whatever is there — so an AI regeneration destroys hand-written text. Writing to the `:ai_generated` row instead leaves a `:manual` row untouched, and `:manual` precedes `:ai_generated` in `Descriptions::SourcePriority::ORDER`, so the human's text keeps winning.
+
+**Files:**
+- Modify: `web-app/app/lib/services/ai/tasks/music/album_description_task.rb`
+- Modify: `web-app/app/lib/services/ai/tasks/music/artist_description_task.rb`
+- Test: `web-app/test/lib/services/ai/tasks/album_description_task_test.rb`
+- Test: `web-app/test/lib/services/ai/tasks/artist_description_task_test.rb`
+
+**Interfaces:**
+- Consumes: `Describable#assign_description(source:, content:) → Description | nil` (Task 1).
+- Produces: no new public interface. `process_and_persist` keeps returning `Services::Ai::Result.new(success: true, data: data, ai_chat: chat)`.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `web-app/test/lib/services/ai/tasks/album_description_task_test.rb`, replace the body of the existing `"process_and_persist updates album description when provided"` test's assertions so it asserts the row rather than the column, and add two tests. The existing test's `provider_response` construction stays as-is; only the assertion changes:
+
+```ruby
+            # was: assert_equal "...", @album.description
+            row = @album.descriptions.reload.find_by(source: :ai_generated)
+            assert_equal "The Dark Side of the Moon is Pink Floyd's groundbreaking concept album exploring themes of conflict and mental illness.", row.content
+            assert_equal "summary", row.kind
+            assert_equal "en", row.locale
+```
+
+Then add:
+
+```ruby
+          test "process_and_persist does not write the description column" do
+            provider_response = {
+              parsed: {
+                description: "A new AI description.",
+                abstained: false,
+                abstain_reason: nil
+              }
+            }
+            original_column = @album.description
+
+            @task.send(:process_and_persist, provider_response)
+
+            assert_equal original_column, @album.reload.description
+          end
+
+          # Regression: the old parent.update!(description:) clobbered whatever was there.
+          test "process_and_persist leaves a preferred manual description untouched" do
+            album = music_albums(:animals)
+            manual = album.descriptions.create!(
+              kind: :summary, locale: "en", source: :manual,
+              content: "Hand-written by an editor.", rank: :preferred
+            )
+            task = AlbumDescriptionTask.new(parent: album)
+            provider_response = {
+              parsed: {
+                description: "AI text that must not win.",
+                abstained: false,
+                abstain_reason: nil
+              }
+            }
+
+            task.send(:process_and_persist, provider_response)
+
+            manual.reload
+            assert_equal "Hand-written by an editor.", manual.content
+            assert_equal "preferred", manual.rank
+            assert_equal "AI text that must not win.",
+              album.descriptions.reload.find_by(source: :ai_generated).content
+            assert_equal manual, album.primary_description
+          end
+```
+
+Apply the same three changes to `artist_description_task_test.rb`, substituting the artist fixtures — `@artist` for `@album`, `music_artists(:roger_waters)` for the clean parent, and `ArtistDescriptionTask`. Confirm the existing setup's fixture name before editing.
+
+The two existing "does not update when nil / blank" tests keep working unchanged, since a blank description still writes nothing.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `bin/rails test test/lib/services/ai/tasks/album_description_task_test.rb test/lib/services/ai/tasks/artist_description_task_test.rb`
+
+Expected: FAIL — the new row does not exist, because the task still writes the column.
+
+- [ ] **Step 3: Write the implementation**
+
+In `album_description_task.rb`, replace the persist branch:
+
+```ruby
+          def process_and_persist(provider_response)
+            data = provider_response[:parsed]
+
+            if data[:description].present? && !data[:abstained]
+              parent.assign_description(source: :ai_generated, content: data[:description])&.save!
+            end
+
+            Services::Ai::Result.new(success: true, data: data, ai_chat: chat)
+          end
+```
+
+The row is saved directly rather than via `parent.save!` because the parent is always persisted here, and saving the album would fire its search-indexing callbacks for a change that does not affect the index.
+
+Make the identical change in `artist_description_task.rb`.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `bin/rails test test/lib/services/ai/tasks/album_description_task_test.rb test/lib/services/ai/tasks/artist_description_task_test.rb`
+
+Expected: PASS.
+
+- [ ] **Step 5: Run the AI provider tests that wrap these tasks**
+
+Run: `bin/rails test test/lib/data_importers/music/album/providers/ai_description_test.rb test/lib/data_importers/music/artist/providers/ai_description_test.rb`
+
+Expected: PASS. These drive the tasks through the importer; if they assert on `.description`, update them the same way.
+
+- [ ] **Step 6: Lint and commit**
+
+```bash
+cd web-app && bundle exec standardrb --fix app/lib/services/ai/tasks/music/ test/lib/services/ai/tasks/
+git add web-app/app/lib/services/ai/tasks/music/ web-app/test/lib/services/ai/tasks/ web-app/test/lib/data_importers/music/
+git commit -m "Write music AI descriptions to their own Description row
+
+Ends the clobber: regenerating an AI description no longer overwrites a
+hand-written manual row, which still outranks it in SourcePriority::ORDER.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: IGDB providers
+
+These assign attributes to a record that **may not be persisted yet** — `ImporterBase#run_providers_with_saving` calls `provider.populate(item, query:)` and then `item.save!`. So the provider must only assign, exactly as `create_identifier` already does, and let the parent's save cascade through `autosave: true`.
+
+**Files:**
+- Modify: `web-app/app/lib/data_importers/games/game/providers/igdb.rb`
+- Modify: `web-app/app/lib/data_importers/games/company/providers/igdb.rb`
+- Test: `web-app/test/lib/data_importers/games/game/providers/igdb_test.rb`
+- Test: `web-app/test/lib/data_importers/games/company/providers/igdb_test.rb`
+
+**Interfaces:**
+- Consumes: `Describable#assign_description(source:, content:) → Description | nil` (Task 1) and the `autosave: true` association from the same task.
+- Produces: no new public interface. `populate` keeps returning a `ProviderResult`.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `web-app/test/lib/data_importers/games/game/providers/igdb_test.rb`, change the assertion in `"populate sets game attributes from IGDB data"`:
+
+```ruby
+            # was: assert_equal "An open-world adventure game", @game.description
+            row = @game.descriptions.detect { |d| d.source == "igdb" }
+            assert_not_nil row, "expected an igdb description to be built"
+            assert_equal "An open-world adventure game", row.content
+            assert_equal "summary", row.kind
+            assert_equal "normal", row.rank
+            assert_nil @game.description
+```
+
+Then add two tests to the same file:
+
+```ruby
+          # The C1/C2a contract: a re-import must persist a CHANGED summary.
+          # This fails silently if autosave: true is removed, or if assign_description
+          # is refactored back to find_or_initialize_by.
+          test "re-import persists a changed summary on an already-saved game" do
+            game = games_games(:tears_of_the_kingdom)
+            game.descriptions.create!(
+              kind: :summary, locale: "en", source: :igdb, content: "Stale summary."
+            )
+            game.reload
+
+            search_service = mock
+            search_service.expects(:find_with_details).with(119388).returns(
+              success: true,
+              data: [{"name" => "Tears of the Kingdom", "summary" => "Fresh summary from IGDB."}]
+            )
+            ::Games::Igdb::Search::GameSearch.stubs(:new).returns(search_service)
+
+            result = @provider.populate(game, query: ImportQuery.new(igdb_id: 119388))
+            assert result.success?
+            game.save!
+
+            assert_equal "Fresh summary from IGDB.",
+              game.descriptions.reload.find_by(source: :igdb).content
+          end
+
+          test "populate leaves the game saveable with a description attached" do
+            search_service = mock
+            search_service.expects(:find_with_details).with(7346).returns(
+              success: true,
+              data: [{"name" => "Breath of the Wild 2", "summary" => "A summary."}]
+            )
+            ::Games::Igdb::Search::GameSearch.stubs(:new).returns(search_service)
+
+            @provider.populate(@game, query: ImportQuery.new(igdb_id: 7346))
+
+            assert @game.valid?, @game.errors.full_messages.join(", ")
+            assert_difference "Description.count", 1 do
+              @game.save!
+            end
+          end
+```
+
+Apply the equivalent changes to `company/providers/igdb_test.rb`, substituting `games_companies(:capcom)` as the already-saved parent and the company provider's own IGDB id and payload shape. Read that file's existing stubs before editing — the company payload key is `"description"`, not `"summary"`.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `bin/rails test test/lib/data_importers/games/game/providers/igdb_test.rb test/lib/data_importers/games/company/providers/igdb_test.rb`
+
+Expected: FAIL — no description row is built, because the providers still write the column.
+
+- [ ] **Step 3: Write the implementation**
+
+In `game/providers/igdb.rb`, inside `populate_game_data`:
+
+```ruby
+          def populate_game_data(game, game_data)
+            game.title = game_data["name"] if game_data["name"].present?
+            game.assign_description(source: :igdb, content: game_data["summary"]) if game_data["summary"].present?
+```
+
+In `company/providers/igdb.rb`, inside `populate_company_data`:
+
+```ruby
+          def populate_company_data(company, company_data)
+            company.name = company_data["name"] if company_data["name"].present?
+            company.assign_description(source: :igdb, content: company_data["description"]) if company_data["description"].present?
+```
+
+Leave the rest of both methods untouched. The `.present?` guard is redundant with the helper's own blank check but is kept for symmetry with the surrounding lines.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `bin/rails test test/lib/data_importers/games/game/providers/igdb_test.rb test/lib/data_importers/games/company/providers/igdb_test.rb`
+
+Expected: PASS.
+
+- [ ] **Step 5: Run the full games importer suite**
+
+Run: `bin/rails test test/lib/data_importers/games/`
+
+Expected: PASS. These exercise the full `ImporterBase` save path, which is where an autosave interaction would surface.
+
+- [ ] **Step 6: Lint and commit**
+
+```bash
+cd web-app && bundle exec standardrb --fix app/lib/data_importers/games/ test/lib/data_importers/games/
+git add web-app/app/lib/data_importers/games/ web-app/test/lib/data_importers/games/
+git commit -m "Write IGDB summaries to their own Description row
+
+Providers assign only; ImporterBase's item.save! cascades via autosave, which
+is what makes a re-import persist a changed summary.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Full-suite gate
+
+`autosave: true` touches 11 models, so the increment is not done until the whole suite is green.
+
+**Files:** none — verification only.
+
+**Interfaces:** none.
+
+- [ ] **Step 1: Run the full suite and lint**
+
+```bash
+cd web-app && bundle exec standardrb && bin/rails test
+```
+
+Expected: `standardrb` clean; suite green (4,944 runs as of increment b2, plus this increment's new tests, 0 failures, 0 errors).
+
+- [ ] **Step 2: Confirm no `description` column writes remain in the four sites**
+
+```bash
+cd web-app && grep -rn 'description' \
+  app/lib/services/ai/tasks/music/album_description_task.rb \
+  app/lib/services/ai/tasks/music/artist_description_task.rb \
+  app/lib/data_importers/games/game/providers/igdb.rb \
+  app/lib/data_importers/games/company/providers/igdb.rb | grep -E '\.description\s*=|update!\(description'
+```
+
+Expected: **no output.** Any hit is a site that still writes the column.
+
+- [ ] **Step 3: Report**
+
+No commit. Report the suite counts and the grep result. If the suite is not green, report the failures precisely and do not claim completion.
+
+---
+
+## Self-Review
+
+**1. Spec coverage.** C1 (`autosave: true`) → Task 1. C2 (one helper, callers persist) → Task 1 + the persistence split across Tasks 2 and 3. C2a (`detect`, not `find_or_initialize_by`) → Task 1 Step 3, pinned by Task 1's "persists a changed existing description" and Task 3's re-import test. The spec's write-path table's four rows → Tasks 2 and 3. The clobber regression → Task 2. "An import still succeeds end-to-end" → Task 3's "leaves the game saveable" plus Task 3 Step 5. Out of scope here and deferred to c2/c3 as the spec says: the admin panel, the `Games::Series` registry entry, form stripping, E2E.
+
+**2. Placeholder scan.** Every code step carries real code. Three steps deliberately say "read the file first and substitute" rather than inventing content — the artist task test's fixture name, the company IGDB payload shape, and the music AI-provider tests' assertions — because those files were not read in full while planning and guessing their contents would be worse than instructing the implementer to look. Each names exactly what to check.
+
+**3. Type consistency.** `assign_description(source:, content:, **attrs)` returns `Description | nil` in Task 1 and is called with exactly that signature in Tasks 2 and 3. Task 2 uses `&.save!` on the return value (parent persisted); Task 3 discards the return value and relies on the parent's cascade (parent may be new) — the two persistence styles are deliberate and match the spec's table. `d.source == source.to_s` in the helper because the enum reader returns a `String` while every caller passes a `Symbol`.

--- a/docs/superpowers/specs/2026-07-29-descriptions-c-write-paths-admin-design.md
+++ b/docs/superpowers/specs/2026-07-29-descriptions-c-write-paths-admin-design.md
@@ -44,7 +44,7 @@ written at all. Two halves:
 | # | Decision | Rationale |
 |---|---|---|
 | C1 | `has_many :descriptions` gains `autosave: true` | Rails autosaves *new* children on parent save but **not modified existing ones**. The IGDB providers assign in memory and `ImporterBase#run_providers_with_saving` calls `item.save!`, so without this a **re-import** of a game that already has an `:igdb` row would assign the new summary and silently not persist it. `Identifier` dodges this only because both its attributes are lookup keys, so a found record is never dirty; `content` is not a lookup key. **The delta cuts both ways:** without `autosave`, Rails validates and saves only *new* children in the collection; with it, *changed persisted* children are validated and saved too. So an invalid changed child can now block a parent's save where previously it would have been silently ignored — which is the correct trade (silent data loss is worse than a loud failure), but it is a new failure path and gets its own test. Escape hatch if it ever misbehaves: `row.save! if persisted?` inside the helper instead, with no app-wide change. |
-| C2 | One `Describable#assign_description` helper; callers persist | The two write paths genuinely differ — the AI tasks' parent is always persisted, the IGDB providers' may be a brand-new record that cannot be saved independently. A helper that only *assigns* serves both, and puts the lookup rule and D5's never-write-`rank` invariant in one place instead of four. |
+| C2 | One `Describable#assign_description` helper; callers persist | The two write paths genuinely differ — the AI tasks' parent is always persisted, the IGDB providers' may be a brand-new record that cannot be saved independently. A helper that only *assigns* serves both, and puts the lookup rule and D5's never-write-`rank` invariant in one place instead of four. `kind:` and `locale:` are real keyword arguments, not part of `**attrs`: splatting them into `assign_attributes` while the lookup hardcoded `summary`/`en` would let a caller build a `summary` row and then override it to `long`, so the next `kind: :long` call would miss it on lookup and build a duplicate, violating the natural-key unique index. |
 | C2a | The helper looks the row up with `detect` over the association, **never `find_or_initialize_by`** | Verified empirically on PG 17 / Rails 8.1, and this is the one that would have shipped a silent bug. `find_or_initialize_by` on a *persisted* parent issues a query and returns a **detached instance that is not in the association's target**; `autosave` only iterates the target, so the parent save is a silent no-op and the content never changes — precisely the failure C1 exists to prevent. `detect` returns the target instance (or `build` puts a new one there), so autosave sees it. Costs one association load; entities carry 1–4 rows (D8), and `primary_description` already operates on the loaded collection. Also removes a second hazard: on a *new* parent, `find_or_initialize_by`'s null-scope query cannot see an already-built in-memory row, so a repeat call would build a duplicate and the natural-key index would reject the save. `detect` finds it. |
 | C3 | Admin `create` offers a full source picker plus `source_url` and `license` | Owner's call. Restricting humans to `:manual` sounds safer but is not: an admin pasting Wikipedia text would be recorded as `:manual`, which is wrong provenance (D10) **and** an unattributed CC BY-SA use, since increment (d)'s `AttributionComponent` keys off `license` + `source_url`. Mislabelling is possible but visible; silent misattribution is neither. |
 | C4 | `rank` appears in no form; only `set_preferred` changes it | D5. A form that could set `preferred` directly would skip the demotion and hit `index_descriptions_one_preferred_per_key`, raising `PG::UniqueViolation`. |
@@ -58,11 +58,11 @@ written at all. Two halves:
 # app/models/concerns/describable.rb
 has_many :descriptions, -> { order(:id) }, as: :describable, dependent: :destroy, autosave: true
 
-def assign_description(source:, content:, **attrs)
+def assign_description(source:, content:, kind: :summary, locale: "en", **attrs)
   return nil if content.blank?
 
-  row = descriptions.detect { |d| d.kind == "summary" && d.locale == "en" && d.source == source.to_s } ||
-    descriptions.build(kind: :summary, locale: "en", source: source)
+  row = descriptions.detect { |d| d.kind == kind.to_s && d.locale == locale && d.source == source.to_s } ||
+    descriptions.build(kind: kind, locale: locale, source: source)
   row.assign_attributes(content: content, retrieved_at: Time.current, **attrs)
   row
 end
@@ -72,7 +72,8 @@ Never assigns `rank` (D5). Returns `nil` on blank content, so `descriptions_cont
 never abort a caller's save. `detect`, not `find_or_initialize_by` — see C2a; the latter returns a
 detached instance and silently loses the write.
 
-`d.source == source.to_s` because the enum reader returns a `String` while callers pass a `Symbol`.
+`d.kind == kind.to_s` and `d.source == source.to_s` because the enum readers return a `String`
+while callers pass a `Symbol`.
 
 ### Verified behaviour (PG 17 / Rails 8.1, 2026-07-30)
 

--- a/docs/superpowers/specs/2026-07-29-descriptions-c-write-paths-admin-design.md
+++ b/docs/superpowers/specs/2026-07-29-descriptions-c-write-paths-admin-design.md
@@ -1,0 +1,207 @@
+# Descriptions (c) — Write Paths & Admin Panel — Design
+
+Increment (c) of the descriptions subsystem. Parent spec:
+`docs/superpowers/specs/2026-07-27-descriptions-subsystem-design.md`.
+
+Increments (a), (b1) and (b2) are merged (PRs #180, #181, #182). The `Description` table holds 198,016
+rows in development and 0 in production. Nothing reads `Description` yet — that is increment (d).
+
+## Goal
+
+Make `Description` the thing that gets **written**, so the eleven `description` columns can stop being
+written at all. Two halves:
+
+1. The four importer/AI write sites stop clobbering `parent.description` and write their own source's row.
+2. An admin panel to view, create, edit, delete and select descriptions — replacing the plain textarea
+   that is being removed from nine forms.
+
+## Scope
+
+**In:**
+
+- Rewire 4 write sites (2 music AI tasks, 2 IGDB providers).
+- `Describable#assign_description` + `autosave: true` on the association.
+- `Admin::DescriptionsController` — `index`, `create`, `update`, `destroy`, `set_preferred`.
+- Nested panel on the 9 describables that have admin pages.
+- `Admin::DomainRouting` entry for `Games::Series`.
+- Remove the description field from 9 `_form` partials **and** `:description` from 9 controllers'
+  strong params.
+- Tests + Playwright E2E.
+
+**Out:**
+
+- **Bulk set-preferred-by-list.** Owner's call, 2026-07-29. It belongs on List admin pages, not on a
+  describable's show page, and needs its own routes, an affected-count preview and a cross-record
+  transaction. It is the operation with proven demand (the legacy site's "flip every book on this list
+  to Goodreads" button), so it is deferred, not dropped.
+- **A `deprecated` rank control.** b2 sets no deprecated rows and nothing reads the value yet, so a
+  control would be inert. Additive later.
+- **Public read views** — increment (d).
+- **`Movies::Movie` / `Movies::Person`.** No movies admin exists and both tables are empty.
+
+## Decisions
+
+| # | Decision | Rationale |
+|---|---|---|
+| C1 | `has_many :descriptions` gains `autosave: true` | Rails autosaves *new* children on parent save but **not modified existing ones**. The IGDB providers assign in memory and `ImporterBase#run_providers_with_saving` calls `item.save!`, so without this a **re-import** of a game that already has an `:igdb` row would assign the new summary and silently not persist it. `Identifier` dodges this only because both its attributes are lookup keys, so a found record is never dirty; `content` is not a lookup key. **The delta cuts both ways:** without `autosave`, Rails validates and saves only *new* children in the collection; with it, *changed persisted* children are validated and saved too. So an invalid changed child can now block a parent's save where previously it would have been silently ignored — which is the correct trade (silent data loss is worse than a loud failure), but it is a new failure path and gets its own test. Escape hatch if it ever misbehaves: `row.save! if persisted?` inside the helper instead, with no app-wide change. |
+| C2 | One `Describable#assign_description` helper; callers persist | The two write paths genuinely differ — the AI tasks' parent is always persisted, the IGDB providers' may be a brand-new record that cannot be saved independently. A helper that only *assigns* serves both, and puts the lookup rule and D5's never-write-`rank` invariant in one place instead of four. |
+| C3 | Admin `create` offers a full source picker plus `source_url` and `license` | Owner's call. Restricting humans to `:manual` sounds safer but is not: an admin pasting Wikipedia text would be recorded as `:manual`, which is wrong provenance (D10) **and** an unattributed CC BY-SA use, since increment (d)'s `AttributionComponent` keys off `license` + `source_url`. Mislabelling is possible but visible; silent misattribution is neither. |
+| C4 | `rank` appears in no form; only `set_preferred` changes it | D5. A form that could set `preferred` directly would skip the demotion and hit `index_descriptions_one_preferred_per_key`, raising `PG::UniqueViolation`. |
+| C5 | `kind` and `locale` are hardcoded `:summary` / `"en"` on create | Every row in the app is that today. D2/D3 justify the *columns* existing for a future the UI does not need yet. Rows at other values still list and delete; they just cannot be created here. |
+| C6 | `Games::Series` gets an `Admin::DomainRouting` entry | It has full admin CRUD but is absent from the registry, so `path_for` returns nil and it cannot host a nested panel. Adding it is a config entry, which is how that registry is designed to grow. It also closes a read-path gap: `admin/games/series/_table.html.erb:29` reads `series.description` and would break at increment (e). |
+| C7 | Stripping the field from the 9 forms is not optional | Once (d) reads `primary_description`, a form writing the column is a control that silently does nothing; at (e) it references a dropped column and errors. |
+
+## Write path
+
+```ruby
+# app/models/concerns/describable.rb
+has_many :descriptions, -> { order(:id) }, as: :describable, dependent: :destroy, autosave: true
+
+def assign_description(source:, content:, **attrs)
+  return nil if content.blank?
+
+  descriptions.find_or_initialize_by(kind: :summary, locale: "en", source: source)
+    .tap { |d| d.assign_attributes(content: content, retrieved_at: Time.current, **attrs) }
+end
+```
+
+Never assigns `rank` (D5). Returns `nil` on blank content, so `descriptions_content_not_blank` can
+never abort a caller's save.
+
+| Site | Parent state | How it persists |
+|---|---|---|
+| `DataImporters::Games::Game::Providers::Igdb#populate_game_data` | may be unsaved | assign only; `ImporterBase#run_providers_with_saving`'s `item.save!` cascades (C1) |
+| `DataImporters::Games::Company::Providers::Igdb` | may be unsaved | same |
+| `Services::Ai::Tasks::Music::AlbumDescriptionTask#process_and_persist` | always persisted | `parent.assign_description(source: :ai_generated, content: data[:description])&.save!` |
+| `Services::Ai::Tasks::Music::ArtistDescriptionTask` | always persisted | same |
+
+Both IGDB providers keep their existing `if ...present?` guard. The AI tasks keep their
+`present? && !abstained` guard. Neither path writes the `description` column any more.
+
+**The clobber bug dies here.** `parent.update!(description:)` overwrote whatever was there, so an AI
+regeneration destroyed hand-written text. Writing to the `:ai_generated` row leaves a `:manual` row
+untouched, and `:manual` outranks `:ai_generated` in `SourcePriority::ORDER`, so the human's text keeps
+winning. Pinned by a regression test.
+
+## Admin panel
+
+Mirrors `Admin::ImagesController`: a single global controller, `index`/`create` nested per parent,
+`update`/`destroy`/`set_preferred` global, a lazily-loaded `turbo_frame_tag "descriptions_list"`, and
+`Admin::DomainScopedAuth` + `require_domain_write!`.
+
+```ruby
+# nested, per parent
+resources :descriptions, only: [:index, :create], controller: "/admin/descriptions"
+
+# global
+resources :descriptions, only: [:update, :destroy], controller: "descriptions" do
+  member { post :set_preferred }
+end
+```
+
+Mounted on the show page the same way images are:
+
+```erb
+<%= turbo_frame_tag "descriptions_list", loading: :lazy, src: admin_album_descriptions_path(@album) do %>
+```
+
+### `set_preferred`
+
+Demote-then-promote inside a transaction. It **cannot** mirror `Image#unset_other_primary_images`, an
+`after_save` that promotes first — under D14's partial unique index that ordering violates the
+constraint mid-callback.
+
+```ruby
+Description.transaction do
+  Description
+    .where(describable_type: @description.describable_type, describable_id: @description.describable_id,
+      kind: @description.kind, locale: @description.locale, rank: :preferred)
+    .where.not(id: @description.id)
+    .update_all(rank: 0) # 0 = :normal; update_all bypasses enum casting
+  @description.update!(rank: :preferred)
+end
+```
+
+`update_all` is deliberate: one statement, no callbacks, and no intermediate state visible to another
+connection. It takes the raw integer `0` because `update_all` writes straight to SQL without the enum
+cast. `where.not(id:)` makes the action idempotent — re-running it on the row that is already preferred
+must not demote the row it is about to promote.
+
+### Form fields
+
+`content`, `source`, `source_name`, `source_url`, `license`. `source_name` is shown only when `source`
+is `:other` — the model enforces the biconditional (`presence` if `source_other?`, `absence` otherwise)
+and `descriptions_source_name_matches_source` enforces it in the database.
+
+A duplicate `(describable, kind, locale, source, source_name)` is caught by the model's uniqueness
+validation and surfaces as a form error, not a 500.
+
+### Not to copy from `Admin::ImagesController`
+
+The polymorphic association is `describable`, not `parent` (the `_able` convention), so
+`params[:parent_type]` and `parent.images` have no equivalent. And per D13 this is a review-and-select
+surface: `create` exists as an override, but the emphasis is view / `set_preferred` / delete.
+
+## Parents (9)
+
+| Domain | Models | Registry work |
+|---|---|---|
+| Music | `Music::Album`, `Music::Artist`, `Music::Song` | none — all in `ENTITIES` + `NESTED_PARENTS` |
+| Games | `Games::Game`, `Games::Company` | none |
+| Games | `Games::Series` | **add to `ENTITIES` and `NESTED_PARENTS[:games]` as `series_id`** (C6) |
+| Books | `Books::Book`, `Books::Author`, `Books::Series` | none |
+
+`Books::Edition` is in `ENTITIES` but is **not** `Describable` and gets no panel.
+
+## Forms and strong params (9 each)
+
+Remove the description field from `admin/{books/{books,authors,series},games/{games,companies,series},music/{albums,artists,songs}}/_form.html.erb`
+and `:description` from the matching controllers' `permit` lists. Verified: all nine currently permit it.
+
+`admin/penalties/_form` and both `ranking_configurations/_form` partials **keep** theirs — authored
+config, not sourced content.
+
+## Testing
+
+- `Admin::DescriptionsControllerTest` — CRUD, `set_preferred`, and `require_domain_write!` denials.
+- **Clobber regression:** AI regeneration writes its own row and leaves a `:manual` `preferred` row
+  untouched in both content and rank.
+- **`set_preferred` demotes the incumbent** rather than raising `PG::UniqueViolation`.
+- **IGDB re-import persists a changed summary** — the C1 autosave gap. This is the test that fails if
+  `autosave: true` is ever removed.
+- **An import still succeeds end-to-end** with the description association in play, proving `autosave`
+  did not introduce a child-validation path that blocks `item.save!`.
+- Updated importer and controller tests for the nine stripped forms.
+- Playwright E2E: add a description, set it preferred, delete it.
+
+Gate: `bin/rails test`, `bin/rails test:system`, `bundle exec standardrb`.
+
+## Deploy ordering
+
+Owner's constraint, 2026-07-29: **the production backfill runs before (c) ships.**
+
+`data_migration:description_columns` (b1) and `data_migration:descriptions` (b2) have never run in
+production. (c) is display-safe at `Description.count = 0`, since the public views still read the
+columns until (d) — but stripping the field from the nine forms makes any production description that
+exists only as a column **un-editable**, because the panel reads `Description` rows and there would be
+none.
+
+Two prerequisites for the b2 half of that production run, neither verified yet:
+
+- production must be able to reach the `legacy_books` database;
+- production must have `Books::Book` / `Books::Author` rows.
+
+If the books data is not in production, `BookDescriptionMigrator` raises on the first legacy book —
+`preload_context` builds the id set upfront — so it fails on batch one with zero rows written, and the
+`abort` added in b2's final review stops the chain before the safety net can run. No partial state.
+b1 is independent of all of this and can run regardless.
+
+## Suggested increments
+
+1. **Write path** — `autosave: true`, `Describable#assign_description`, 4 sites rewired, clobber
+   regression + IGDB re-import tests. No UI.
+2. **Admin panel** — controller, routes, views, `set_preferred`, `Games::Series` registry entry, E2E.
+3. **Form stripping** — 9 forms + 9 strong-param lists, updated controller tests.
+
+Increment 3 must land with or after 2: once the field is gone, the panel is the only way to edit a
+description.

--- a/docs/superpowers/specs/2026-07-29-descriptions-c-write-paths-admin-design.md
+++ b/docs/superpowers/specs/2026-07-29-descriptions-c-write-paths-admin-design.md
@@ -215,6 +215,19 @@ If the books data is not in production, `BookDescriptionMigrator` raises on the 
 `abort` added in b2's final review stops the chain before the safety net can run. No partial state.
 b1 is independent of all of this and can run regardless.
 
+### c1 alone is not deployable
+
+The backfill constraint above covers *existing* descriptions. c1 (the write path) also affects
+*newly written* ones: after c1, a freshly imported IGDB game or company, and every AI description
+regeneration, write only a `Description` row — but every public and admin view still reads the
+`description` **column** until increment (d). So a game imported the day after c1 deploys would show
+no description anywhere, and without c2's admin panel there would be no way to even see the text that
+was written. Existing data is unaffected; this only bites records touched after c1 deploys.
+
+c1 must therefore not reach production on its own — it needs (d), the read path, for newly-written
+descriptions to be visible. c2's admin panel makes them at least inspectable sooner, but does not
+substitute for (d).
+
 ## Suggested increments
 
 1. **Write path** — `autosave: true`, `Describable#assign_description`, 4 sites rewired, clobber

--- a/docs/superpowers/specs/2026-07-29-descriptions-c-write-paths-admin-design.md
+++ b/docs/superpowers/specs/2026-07-29-descriptions-c-write-paths-admin-design.md
@@ -45,6 +45,7 @@ written at all. Two halves:
 |---|---|---|
 | C1 | `has_many :descriptions` gains `autosave: true` | Rails autosaves *new* children on parent save but **not modified existing ones**. The IGDB providers assign in memory and `ImporterBase#run_providers_with_saving` calls `item.save!`, so without this a **re-import** of a game that already has an `:igdb` row would assign the new summary and silently not persist it. `Identifier` dodges this only because both its attributes are lookup keys, so a found record is never dirty; `content` is not a lookup key. **The delta cuts both ways:** without `autosave`, Rails validates and saves only *new* children in the collection; with it, *changed persisted* children are validated and saved too. So an invalid changed child can now block a parent's save where previously it would have been silently ignored — which is the correct trade (silent data loss is worse than a loud failure), but it is a new failure path and gets its own test. Escape hatch if it ever misbehaves: `row.save! if persisted?` inside the helper instead, with no app-wide change. |
 | C2 | One `Describable#assign_description` helper; callers persist | The two write paths genuinely differ — the AI tasks' parent is always persisted, the IGDB providers' may be a brand-new record that cannot be saved independently. A helper that only *assigns* serves both, and puts the lookup rule and D5's never-write-`rank` invariant in one place instead of four. |
+| C2a | The helper looks the row up with `detect` over the association, **never `find_or_initialize_by`** | Verified empirically on PG 17 / Rails 8.1, and this is the one that would have shipped a silent bug. `find_or_initialize_by` on a *persisted* parent issues a query and returns a **detached instance that is not in the association's target**; `autosave` only iterates the target, so the parent save is a silent no-op and the content never changes — precisely the failure C1 exists to prevent. `detect` returns the target instance (or `build` puts a new one there), so autosave sees it. Costs one association load; entities carry 1–4 rows (D8), and `primary_description` already operates on the loaded collection. Also removes a second hazard: on a *new* parent, `find_or_initialize_by`'s null-scope query cannot see an already-built in-memory row, so a repeat call would build a duplicate and the natural-key index would reject the save. `detect` finds it. |
 | C3 | Admin `create` offers a full source picker plus `source_url` and `license` | Owner's call. Restricting humans to `:manual` sounds safer but is not: an admin pasting Wikipedia text would be recorded as `:manual`, which is wrong provenance (D10) **and** an unattributed CC BY-SA use, since increment (d)'s `AttributionComponent` keys off `license` + `source_url`. Mislabelling is possible but visible; silent misattribution is neither. |
 | C4 | `rank` appears in no form; only `set_preferred` changes it | D5. A form that could set `preferred` directly would skip the demotion and hit `index_descriptions_one_preferred_per_key`, raising `PG::UniqueViolation`. |
 | C5 | `kind` and `locale` are hardcoded `:summary` / `"en"` on create | Every row in the app is that today. D2/D3 justify the *columns* existing for a future the UI does not need yet. Rows at other values still list and delete; they just cannot be created here. |
@@ -60,13 +61,29 @@ has_many :descriptions, -> { order(:id) }, as: :describable, dependent: :destroy
 def assign_description(source:, content:, **attrs)
   return nil if content.blank?
 
-  descriptions.find_or_initialize_by(kind: :summary, locale: "en", source: source)
-    .tap { |d| d.assign_attributes(content: content, retrieved_at: Time.current, **attrs) }
+  row = descriptions.detect { |d| d.kind == "summary" && d.locale == "en" && d.source == source.to_s } ||
+    descriptions.build(kind: :summary, locale: "en", source: source)
+  row.assign_attributes(content: content, retrieved_at: Time.current, **attrs)
+  row
 end
 ```
 
 Never assigns `rank` (D5). Returns `nil` on blank content, so `descriptions_content_not_blank` can
-never abort a caller's save.
+never abort a caller's save. `detect`, not `find_or_initialize_by` — see C2a; the latter returns a
+detached instance and silently loses the write.
+
+`d.source == source.to_s` because the enum reader returns a `String` while callers pass a `Symbol`.
+
+### Verified behaviour (PG 17 / Rails 8.1, 2026-07-30)
+
+| Case | Result |
+|---|---|
+| `find_or_initialize_by` + `parent.save!`, persisted parent, existing row | **Silently does not update** — instance is not in the association target |
+| ...same, association pre-loaded | **Still does not update** — `find_by` issues a fresh query either way |
+| `detect` + `parent.save!`, persisted parent, existing row | Updates correctly |
+| `detect` + `parent.save!` **without** `autosave: true` | **Does not update** — so C1's association change is genuinely required |
+| `build` on a new parent, no `autosave` | Saves (new children always do), so `autosave` matters only for the changed-existing case |
+| `autosave: true` with an invalid changed child | Blocks the parent save with `RecordInvalid` — the new failure path named in C1 |
 
 | Site | Parent state | How it persists |
 |---|---|---|
@@ -168,7 +185,9 @@ config, not sourced content.
   untouched in both content and rank.
 - **`set_preferred` demotes the incumbent** rather than raising `PG::UniqueViolation`.
 - **IGDB re-import persists a changed summary** — the C1 autosave gap. This is the test that fails if
-  `autosave: true` is ever removed.
+  `autosave: true` is ever removed **or** if the helper's `detect` is refactored back into
+  `find_or_initialize_by` (C2a). Both regressions are silent without it, so it is the single most
+  load-bearing test in this increment.
 - **An import still succeeds end-to-end** with the description association in play, proving `autosave`
   did not introduce a child-validation path that blocks `item.save!`.
 - Updated importer and controller tests for the nine stripped forms.

--- a/web-app/app/lib/data_importers/games/company/providers/igdb.rb
+++ b/web-app/app/lib/data_importers/games/company/providers/igdb.rb
@@ -39,7 +39,7 @@ module DataImporters
           # Maps IGDB company data to model attributes
           def populate_company_data(company, company_data)
             company.name = company_data["name"] if company_data["name"].present?
-            company.description = company_data["description"] if company_data["description"].present?
+            company.assign_description(source: :igdb, content: company_data["description"]) if company_data["description"].present?
 
             # Convert IGDB numeric country code to ISO 2-letter
             if company_data["country"].present?

--- a/web-app/app/lib/data_importers/games/game/providers/igdb.rb
+++ b/web-app/app/lib/data_importers/games/game/providers/igdb.rb
@@ -73,7 +73,7 @@ module DataImporters
           # Maps IGDB game data to model attributes
           def populate_game_data(game, game_data)
             game.title = game_data["name"] if game_data["name"].present?
-            game.description = game_data["summary"] if game_data["summary"].present?
+            game.assign_description(source: :igdb, content: game_data["summary"]) if game_data["summary"].present?
 
             # Extract year from IGDB first_release_date (Unix timestamp)
             if game_data["first_release_date"].present?

--- a/web-app/app/lib/services/ai/tasks/music/album_description_task.rb
+++ b/web-app/app/lib/services/ai/tasks/music/album_description_task.rb
@@ -39,12 +39,10 @@ module Services
           end
 
           def process_and_persist(provider_response)
-            # provider_response[:parsed] is validated data from schema
             data = provider_response[:parsed]
 
-            # Only update the album if the AI provided a description
             if data[:description].present? && !data[:abstained]
-              parent.update!(description: data[:description])
+              parent.assign_description(source: :ai_generated, content: data[:description])&.save!
             end
 
             Services::Ai::Result.new(success: true, data: data, ai_chat: chat)

--- a/web-app/app/lib/services/ai/tasks/music/artist_description_task.rb
+++ b/web-app/app/lib/services/ai/tasks/music/artist_description_task.rb
@@ -37,12 +37,10 @@ module Services
           end
 
           def process_and_persist(provider_response)
-            # provider_response[:parsed] is validated data from schema
             data = provider_response[:parsed]
 
-            # Only update the artist if the AI provided a description
             if data[:description].present? && !data[:abstained]
-              parent.update!(description: data[:description])
+              parent.assign_description(source: :ai_generated, content: data[:description])&.save!
             end
 
             Services::Ai::Result.new(success: true, data: data, ai_chat: chat)

--- a/web-app/app/models/concerns/describable.rb
+++ b/web-app/app/models/concerns/describable.rb
@@ -2,10 +2,24 @@ module Describable
   extend ActiveSupport::Concern
 
   included do
-    has_many :descriptions, -> { order(:id) }, as: :describable, dependent: :destroy
+    has_many :descriptions, -> { order(:id) }, as: :describable, dependent: :destroy, autosave: true
   end
 
   def primary_description(kind: :summary, locale: "en")
     Descriptions::Resolver.call(descriptions, kind: kind, locale: locale)
+  end
+
+  # Assigns without saving, so an importer can call this on a record that is not
+  # persisted yet and let the parent's save cascade. Looks the row up with detect
+  # rather than find_or_initialize_by: the latter queries and returns an instance
+  # that is not in the association target, which autosave never sees, so the write
+  # is silently lost. Never assigns rank (D5).
+  def assign_description(source:, content:, **attrs)
+    return nil if content.blank?
+
+    row = descriptions.detect { |d| d.kind == "summary" && d.locale == "en" && d.source == source.to_s } ||
+      descriptions.build(kind: :summary, locale: "en", source: source)
+    row.assign_attributes(content: content, retrieved_at: Time.current, **attrs)
+    row
   end
 end

--- a/web-app/app/models/concerns/describable.rb
+++ b/web-app/app/models/concerns/describable.rb
@@ -14,11 +14,11 @@ module Describable
   # rather than find_or_initialize_by: the latter queries and returns an instance
   # that is not in the association target, which autosave never sees, so the write
   # is silently lost. Never assigns rank (D5).
-  def assign_description(source:, content:, **attrs)
+  def assign_description(source:, content:, kind: :summary, locale: "en", **attrs)
     return nil if content.blank?
 
-    row = descriptions.detect { |d| d.kind == "summary" && d.locale == "en" && d.source == source.to_s } ||
-      descriptions.build(kind: :summary, locale: "en", source: source)
+    row = descriptions.detect { |d| d.kind == kind.to_s && d.locale == locale && d.source == source.to_s } ||
+      descriptions.build(kind: kind, locale: locale, source: source)
     row.assign_attributes(content: content, retrieved_at: Time.current, **attrs)
     row
   end

--- a/web-app/test/lib/data_importers/games/company/importer_test.rb
+++ b/web-app/test/lib/data_importers/games/company/importer_test.rb
@@ -72,7 +72,9 @@ module DataImporters
 
           assert result.success?
           assert_equal existing_company, result.item
-          assert_equal "Updated description", result.item.reload.description
+          row = result.item.reload.descriptions.find_by(source: :igdb)
+          assert_equal "Updated description", row.content
+          assert_nil result.item.description
         end
 
         test "call fails when igdb_id is invalid" do

--- a/web-app/test/lib/data_importers/games/company/providers/igdb_test.rb
+++ b/web-app/test/lib/data_importers/games/company/providers/igdb_test.rb
@@ -67,9 +67,9 @@ module DataImporters
 
           test "populate leaves the company saveable with a description attached" do
             search_service = mock
-            search_service.expects(:find_with_details).with(70).returns(
-              success: true,
-              data: [{"name" => "Nintendo", "description" => "A description."}]
+            search_service.stubs(:find_with_details).with(70).returns(
+              {success: true, data: [{"name" => "Nintendo", "description" => "A description."}]},
+              {success: true, data: [{"name" => "Nintendo", "description" => "An updated description."}]}
             )
             ::Games::Igdb::Search::CompanySearch.stubs(:new).returns(search_service)
 
@@ -79,6 +79,14 @@ module DataImporters
             assert_difference "Description.count", 1 do
               @company.save!
             end
+
+            assert_no_difference "Description.count" do
+              @provider.populate(@company, query: ImportQuery.new(igdb_id: 70))
+              @company.save!
+            end
+
+            assert_equal "An updated description.",
+              @company.descriptions.reload.find_by(source: :igdb).content
           end
 
           test "populate creates IGDB identifier" do

--- a/web-app/test/lib/data_importers/games/company/providers/igdb_test.rb
+++ b/web-app/test/lib/data_importers/games/company/providers/igdb_test.rb
@@ -33,9 +33,52 @@ module DataImporters
 
             assert result.success?
             assert_equal "Nintendo", @company.name
-            assert_equal "Japanese video game company", @company.description
+            row = @company.descriptions.detect { |d| d.source == "igdb" }
+            assert_not_nil row, "expected an igdb description to be built"
+            assert_equal "Japanese video game company", row.content
+            assert_equal "summary", row.kind
+            assert_equal "normal", row.rank
+            assert_nil @company.description
             assert_equal "JP", @company.country
             assert_equal 1889, @company.year_founded
+          end
+
+          test "re-import persists a changed description on an already-saved company" do
+            company = games_companies(:capcom)
+            company.descriptions.create!(
+              kind: :summary, locale: "en", source: :igdb, content: "Stale description."
+            )
+            company.reload
+
+            search_service = mock
+            search_service.expects(:find_with_details).with(8).returns(
+              success: true,
+              data: [{"name" => "Capcom", "description" => "Fresh description from IGDB."}]
+            )
+            ::Games::Igdb::Search::CompanySearch.stubs(:new).returns(search_service)
+
+            result = @provider.populate(company, query: ImportQuery.new(igdb_id: 8))
+            assert result.success?
+            company.save!
+
+            assert_equal "Fresh description from IGDB.",
+              company.descriptions.reload.find_by(source: :igdb).content
+          end
+
+          test "populate leaves the company saveable with a description attached" do
+            search_service = mock
+            search_service.expects(:find_with_details).with(70).returns(
+              success: true,
+              data: [{"name" => "Nintendo", "description" => "A description."}]
+            )
+            ::Games::Igdb::Search::CompanySearch.stubs(:new).returns(search_service)
+
+            @provider.populate(@company, query: ImportQuery.new(igdb_id: 70))
+
+            assert @company.valid?, @company.errors.full_messages.join(", ")
+            assert_difference "Description.count", 1 do
+              @company.save!
+            end
           end
 
           test "populate creates IGDB identifier" do

--- a/web-app/test/lib/data_importers/games/game/importer_test.rb
+++ b/web-app/test/lib/data_importers/games/game/importer_test.rb
@@ -81,7 +81,9 @@ module DataImporters
 
           assert result.success?
           assert_equal existing_game, result.item
-          assert_equal "Updated description", result.item.reload.description
+          row = result.item.reload.descriptions.find_by(source: :igdb)
+          assert_equal "Updated description", row.content
+          assert_nil result.item.description
         end
 
         test "call with item parameter re-enriches existing game" do
@@ -109,7 +111,9 @@ module DataImporters
 
           assert result.success?
           assert_equal existing_game, result.item
-          assert_equal "Updated description", result.item.reload.description
+          row = result.item.reload.descriptions.find_by(source: :igdb)
+          assert_equal "Updated description", row.content
+          assert_nil result.item.description
         end
 
         test "call fails when igdb_id is invalid" do

--- a/web-app/test/lib/data_importers/games/game/providers/igdb_test.rb
+++ b/web-app/test/lib/data_importers/games/game/providers/igdb_test.rb
@@ -34,9 +34,52 @@ module DataImporters
 
             assert result.success?
             assert_equal "The Legend of Zelda: Breath of the Wild", @game.title
-            assert_equal "An open-world adventure game", @game.description
+            row = @game.descriptions.detect { |d| d.source == "igdb" }
+            assert_not_nil row, "expected an igdb description to be built"
+            assert_equal "An open-world adventure game", row.content
+            assert_equal "summary", row.kind
+            assert_equal "normal", row.rank
+            assert_nil @game.description
             assert_equal 2017, @game.release_year
             assert_equal "main_game", @game.game_type
+          end
+
+          test "re-import persists a changed summary on an already-saved game" do
+            game = games_games(:tears_of_the_kingdom)
+            game.descriptions.create!(
+              kind: :summary, locale: "en", source: :igdb, content: "Stale summary."
+            )
+            game.reload
+
+            search_service = mock
+            search_service.expects(:find_with_details).with(119388).returns(
+              success: true,
+              data: [{"name" => "Tears of the Kingdom", "summary" => "Fresh summary from IGDB."}]
+            )
+            ::Games::Igdb::Search::GameSearch.stubs(:new).returns(search_service)
+
+            result = @provider.populate(game, query: ImportQuery.new(igdb_id: 119388))
+            assert result.success?
+            game.save!
+
+            assert_equal "Fresh summary from IGDB.",
+              game.descriptions.reload.find_by(source: :igdb).content
+          end
+
+          test "populate leaves the game saveable with a description attached" do
+            search_service = mock
+            search_service.expects(:find_with_details).with(7346).returns(
+              success: true,
+              data: [{"name" => "Breath of the Wild 2", "summary" => "A summary."}]
+            )
+            ::Games::Igdb::Search::GameSearch.stubs(:new).returns(search_service)
+
+            assert_difference "Description.count", 1 do
+              @provider.populate(@game, query: ImportQuery.new(igdb_id: 7346))
+            end
+
+            assert @game.valid?, @game.errors.full_messages.join(", ")
+            assert_nothing_raised { @game.save! }
           end
 
           test "populate creates IGDB identifier" do

--- a/web-app/test/lib/data_importers/games/game/providers/igdb_test.rb
+++ b/web-app/test/lib/data_importers/games/game/providers/igdb_test.rb
@@ -68,9 +68,9 @@ module DataImporters
 
           test "populate leaves the game saveable with a description attached" do
             search_service = mock
-            search_service.expects(:find_with_details).with(7346).returns(
-              success: true,
-              data: [{"name" => "Breath of the Wild 2", "summary" => "A summary."}]
+            search_service.stubs(:find_with_details).with(7346).returns(
+              {success: true, data: [{"name" => "Breath of the Wild 2", "summary" => "A summary."}]},
+              {success: true, data: [{"name" => "Breath of the Wild 2", "summary" => "An updated summary."}]}
             )
             ::Games::Igdb::Search::GameSearch.stubs(:new).returns(search_service)
 
@@ -80,6 +80,14 @@ module DataImporters
 
             assert @game.valid?, @game.errors.full_messages.join(", ")
             assert_nothing_raised { @game.save! }
+
+            assert_no_difference "Description.count" do
+              @provider.populate(@game, query: ImportQuery.new(igdb_id: 7346))
+              @game.save!
+            end
+
+            assert_equal "An updated summary.",
+              @game.descriptions.reload.find_by(source: :igdb).content
           end
 
           test "populate creates IGDB identifier" do

--- a/web-app/test/lib/data_importers/games/game/providers/igdb_test.rb
+++ b/web-app/test/lib/data_importers/games/game/providers/igdb_test.rb
@@ -74,12 +74,15 @@ module DataImporters
             )
             ::Games::Igdb::Search::GameSearch.stubs(:new).returns(search_service)
 
-            assert_difference "Description.count", 1 do
-              @provider.populate(@game, query: ImportQuery.new(igdb_id: 7346))
-            end
+            @provider.populate(@game, query: ImportQuery.new(igdb_id: 7346))
+            assert_equal 1, @game.descriptions.size
 
             assert @game.valid?, @game.errors.full_messages.join(", ")
-            assert_nothing_raised { @game.save! }
+            assert_no_difference "Description.count" do
+              @game.save!
+            end
+            assert_equal "A summary.",
+              @game.descriptions.reload.find_by(source: :igdb).content
 
             assert_no_difference "Description.count" do
               @provider.populate(@game, query: ImportQuery.new(igdb_id: 7346))

--- a/web-app/test/lib/services/ai/tasks/album_description_task_test.rb
+++ b/web-app/test/lib/services/ai/tasks/album_description_task_test.rb
@@ -54,9 +54,52 @@ module Services
             result = @task.send(:process_and_persist, provider_response)
 
             assert result.success?
-            @album.reload
-            assert_equal "The Dark Side of the Moon is Pink Floyd's groundbreaking concept album exploring themes of conflict and mental illness.", @album.description
+            row = @album.descriptions.reload.find_by(source: :ai_generated)
+            assert_equal "The Dark Side of the Moon is Pink Floyd's groundbreaking concept album exploring themes of conflict and mental illness.", row.content
+            assert_equal "summary", row.kind
+            assert_equal "en", row.locale
             assert_equal chat, result.ai_chat
+          end
+
+          test "process_and_persist does not write the description column" do
+            provider_response = {
+              parsed: {
+                description: "A new AI description.",
+                abstained: false,
+                abstain_reason: nil
+              }
+            }
+            original_column = @album.description
+
+            @task.send(:process_and_persist, provider_response)
+
+            assert_equal original_column, @album.reload.description
+          end
+
+          # Regression: the old parent.update!(description:) clobbered whatever was there.
+          test "process_and_persist leaves a preferred manual description untouched" do
+            album = music_albums(:animals)
+            manual = album.descriptions.create!(
+              kind: :summary, locale: "en", source: :manual,
+              content: "Hand-written by an editor.", rank: :preferred
+            )
+            task = AlbumDescriptionTask.new(parent: album)
+            provider_response = {
+              parsed: {
+                description: "AI text that must not win.",
+                abstained: false,
+                abstain_reason: nil
+              }
+            }
+
+            task.send(:process_and_persist, provider_response)
+
+            manual.reload
+            assert_equal "Hand-written by an editor.", manual.content
+            assert_equal "preferred", manual.rank
+            assert_equal "AI text that must not win.",
+              album.descriptions.reload.find_by(source: :ai_generated).content
+            assert_equal manual, album.primary_description
           end
 
           test "process_and_persist does not update when abstained" do

--- a/web-app/test/lib/services/ai/tasks/album_description_task_test.rb
+++ b/web-app/test/lib/services/ai/tasks/album_description_task_test.rb
@@ -103,12 +103,12 @@ module Services
           end
 
           test "process_and_persist does not update when abstained" do
-            original_description = @album.description
+            original_content = @album.descriptions.find_by(source: :ai_generated).content
             provider_response = {
               parsed: {
-                description: nil,
+                description: "Text the AI abstained on.",
                 abstained: true,
-                abstain_reason: "Not enough information about this album"
+                abstain_reason: "Not familiar with this album"
               }
             }
 
@@ -118,12 +118,11 @@ module Services
             result = @task.send(:process_and_persist, provider_response)
 
             assert result.success?
-            @album.reload
-            assert_equal original_description, @album.description
+            assert_equal original_content, @album.descriptions.reload.find_by(source: :ai_generated).content
           end
 
           test "process_and_persist does not update when description is blank" do
-            original_description = @album.description
+            original_content = @album.descriptions.find_by(source: :ai_generated).content
             provider_response = {
               parsed: {
                 description: "",
@@ -138,8 +137,7 @@ module Services
             result = @task.send(:process_and_persist, provider_response)
 
             assert result.success?
-            @album.reload
-            assert_equal original_description, @album.description
+            assert_equal original_content, @album.descriptions.reload.find_by(source: :ai_generated).content
           end
 
           test "ResponseSchema has correct structure" do

--- a/web-app/test/lib/services/ai/tasks/artist_description_task_test.rb
+++ b/web-app/test/lib/services/ai/tasks/artist_description_task_test.rb
@@ -103,12 +103,12 @@ module Services
           end
 
           test "process_and_persist does not update when abstained" do
-            original_description = @artist.description
+            assert_nil @artist.descriptions.find_by(source: :ai_generated)
             provider_response = {
               parsed: {
-                description: nil,
+                description: "Text the AI abstained on.",
                 abstained: true,
-                abstain_reason: "Not enough information about this artist"
+                abstain_reason: "Not familiar with this artist"
               }
             }
 
@@ -118,12 +118,11 @@ module Services
             result = @task.send(:process_and_persist, provider_response)
 
             assert result.success?
-            @artist.reload
-            assert_equal original_description, @artist.description
+            assert_nil @artist.descriptions.reload.find_by(source: :ai_generated)
           end
 
           test "process_and_persist does not update when description is blank" do
-            original_description = @artist.description
+            assert_nil @artist.descriptions.find_by(source: :ai_generated)
             provider_response = {
               parsed: {
                 description: "",
@@ -138,8 +137,7 @@ module Services
             result = @task.send(:process_and_persist, provider_response)
 
             assert result.success?
-            @artist.reload
-            assert_equal original_description, @artist.description
+            assert_nil @artist.descriptions.reload.find_by(source: :ai_generated)
           end
 
           test "ResponseSchema has correct structure" do

--- a/web-app/test/lib/services/ai/tasks/artist_description_task_test.rb
+++ b/web-app/test/lib/services/ai/tasks/artist_description_task_test.rb
@@ -54,9 +54,52 @@ module Services
             result = @task.send(:process_and_persist, provider_response)
 
             assert result.success?
-            @artist.reload
-            assert_equal "Pink Floyd is a British progressive rock band known for their concept albums.", @artist.description
+            row = @artist.descriptions.reload.find_by(source: :ai_generated)
+            assert_equal "Pink Floyd is a British progressive rock band known for their concept albums.", row.content
+            assert_equal "summary", row.kind
+            assert_equal "en", row.locale
             assert_equal chat, result.ai_chat
+          end
+
+          test "process_and_persist does not write the description column" do
+            provider_response = {
+              parsed: {
+                description: "A new AI description.",
+                abstained: false,
+                abstain_reason: nil
+              }
+            }
+            original_column = @artist.description
+
+            @task.send(:process_and_persist, provider_response)
+
+            assert_equal original_column, @artist.reload.description
+          end
+
+          # Regression: the old parent.update!(description:) clobbered whatever was there.
+          test "process_and_persist leaves a preferred manual description untouched" do
+            artist = music_artists(:roger_waters)
+            manual = artist.descriptions.create!(
+              kind: :summary, locale: "en", source: :manual,
+              content: "Hand-written by an editor.", rank: :preferred
+            )
+            task = ArtistDescriptionTask.new(parent: artist)
+            provider_response = {
+              parsed: {
+                description: "AI text that must not win.",
+                abstained: false,
+                abstain_reason: nil
+              }
+            }
+
+            task.send(:process_and_persist, provider_response)
+
+            manual.reload
+            assert_equal "Hand-written by an editor.", manual.content
+            assert_equal "preferred", manual.rank
+            assert_equal "AI text that must not win.",
+              artist.descriptions.reload.find_by(source: :ai_generated).content
+            assert_equal manual, artist.primary_description
           end
 
           test "process_and_persist does not update when abstained" do

--- a/web-app/test/models/concerns/describable_test.rb
+++ b/web-app/test/models/concerns/describable_test.rb
@@ -94,6 +94,34 @@ class DescribableTest < ActiveSupport::TestCase
     assert_equal "cc_by_sa_4", row.license
   end
 
+  test "assign_description keeps kind: long and kind: summary as distinct rows" do
+    album = music_albums(:animals)
+
+    long_row = album.assign_description(source: :ai_generated, content: "The long version.", kind: :long)
+    summary_row = album.assign_description(source: :ai_generated, content: "The summary version.", kind: :summary)
+    album.save!
+
+    assert_not_equal long_row.id, summary_row.id
+    assert_equal 2, album.descriptions.reload.size
+    assert_equal "The long version.", album.descriptions.find_by(kind: :long).content
+    assert_equal "The summary version.", album.descriptions.find_by(kind: :summary).content
+  end
+
+  test "assign_description with kind: long twice updates the same row" do
+    album = music_albums(:animals)
+
+    first = album.assign_description(source: :ai_generated, content: "First long text.", kind: :long)
+    album.save!
+
+    assert_no_difference "Description.count" do
+      second = album.assign_description(source: :ai_generated, content: "Second long text.", kind: :long)
+      assert_equal first.id, second.id
+      album.save!
+    end
+
+    assert_equal "Second long text.", album.descriptions.reload.find_by(kind: :long).content
+  end
+
   # dark_side_ai is an existing ai_generated row on this album, at rank: preferred.
   test "assign_description updates the existing row for that source instead of building a second" do
     album = music_albums(:dark_side_of_the_moon)

--- a/web-app/test/models/concerns/describable_test.rb
+++ b/web-app/test/models/concerns/describable_test.rb
@@ -56,4 +56,108 @@ class DescribableTest < ActiveSupport::TestCase
       book.destroy
     end
   end
+
+  test "assign_description returns nil for blank content" do
+    album = music_albums(:animals)
+    [nil, "", "   ", "\t\n"].each do |blank|
+      assert_nil album.assign_description(source: :ai_generated, content: blank),
+        "expected #{blank.inspect} to be rejected"
+    end
+    assert_empty album.descriptions
+  end
+
+  test "assign_description builds a summary/en row at the given source" do
+    album = music_albums(:animals)
+
+    row = album.assign_description(source: :ai_generated, content: "A concept album about pigs.")
+
+    assert_equal "summary", row.kind
+    assert_equal "en", row.locale
+    assert_equal "ai_generated", row.source
+    assert_equal "A concept album about pigs.", row.content
+    assert_equal "normal", row.rank
+    assert_not_nil row.retrieved_at
+    assert row.new_record?
+  end
+
+  test "assign_description accepts extra attributes" do
+    album = music_albums(:animals)
+
+    row = album.assign_description(
+      source: :wikipedia,
+      content: "From Wikipedia.",
+      source_url: "https://en.wikipedia.org/wiki/Animals",
+      license: :cc_by_sa_4
+    )
+
+    assert_equal "https://en.wikipedia.org/wiki/Animals", row.source_url
+    assert_equal "cc_by_sa_4", row.license
+  end
+
+  # dark_side_ai is an existing ai_generated row on this album, at rank: preferred.
+  test "assign_description updates the existing row for that source instead of building a second" do
+    album = music_albums(:dark_side_of_the_moon)
+    existing = descriptions(:dark_side_ai)
+
+    assert_no_difference "Description.count" do
+      row = album.assign_description(source: :ai_generated, content: "Rewritten by the AI task.")
+      assert_equal existing.id, row.id
+      album.save!
+    end
+
+    assert_equal "Rewritten by the AI task.", existing.reload.content
+  end
+
+  # D5: importers may never write rank.
+  test "assign_description never changes rank" do
+    album = music_albums(:dark_side_of_the_moon)
+
+    album.assign_description(source: :ai_generated, content: "New text.")
+    album.save!
+
+    assert_equal "preferred", descriptions(:dark_side_ai).reload.rank
+  end
+
+  test "assign_description leaves a different source's row alone" do
+    album = music_albums(:dark_side_of_the_moon)
+
+    album.assign_description(source: :wikipedia, content: "A wikipedia row.")
+    album.save!
+
+    assert_equal 2, album.descriptions.reload.size
+    assert_equal "preferred", descriptions(:dark_side_ai).reload.rank
+  end
+
+  test "assign_description works on an unsaved parent and persists with it" do
+    book = Books::Book.new(title: "Assign Description On New Parent")
+
+    book.assign_description(source: :manual, content: "Written before the parent existed.")
+    book.save!
+
+    row = book.descriptions.reload.sole
+    assert_equal "manual", row.source
+    assert_equal "Written before the parent existed.", row.content
+  end
+
+  test "assign_description called twice on an unsaved parent updates one row, not two" do
+    book = Books::Book.new(title: "Assign Description Twice")
+
+    book.assign_description(source: :manual, content: "first")
+    book.assign_description(source: :manual, content: "second")
+    book.save!
+
+    assert_equal ["second"], book.descriptions.reload.pluck(:content)
+  end
+
+  # The autosave contract: without autosave: true this is a silent no-op.
+  test "saving the parent persists a changed existing description" do
+    album = music_albums(:animals)
+    album.descriptions.create!(kind: :summary, locale: "en", source: :ai_generated, content: "old")
+    album.reload
+
+    album.assign_description(source: :ai_generated, content: "new")
+    album.save!
+
+    assert_equal "new", album.descriptions.reload.sole.content
+  end
 end


### PR DESCRIPTION
Increment **(c1)** of the descriptions subsystem — the write half. The four importer/AI sites stop writing the `description` column and each writes its own source's `Description` row instead.

**Scope note for reviewers:** this branch also adds the design spec for increment (c) as a whole. Its **admin panel** and **form stripping** sections are deliberately NOT implemented here — those are c2 and c3, each getting their own plan. Only the write path ships in this PR.

Design: `docs/superpowers/specs/2026-07-29-descriptions-c-write-paths-admin-design.md`
Plan: `docs/superpowers/plans/2026-07-30-descriptions-c1-write-paths.md`

## The clobber bug is dead

`parent.update!(description:)` overwrote whatever was there, so regenerating an AI description silently destroyed hand-written text. Each site now writes only its own source's row:

| Site | Before | After |
|---|---|---|
| `Music::AlbumDescriptionTask` | `parent.update!(description:)` | `assign_description(source: :ai_generated, ...)&.save!` |
| `Music::ArtistDescriptionTask` | same | same |
| `Games::Game::Providers::Igdb` | `game.description = summary` | `assign_description(source: :igdb, ...)`, parent save cascades |
| `Games::Company::Providers::Igdb` | same | same |

A `:manual` row survives an AI regeneration untouched in both content and rank, and still wins `primary_description` because `:manual` precedes `:ai_generated` in `SourcePriority::ORDER`. Pinned by a regression test.

The AI tasks save the returned row directly rather than the parent, so a description change no longer fires the album's search-indexing callbacks — `as_indexed_json` doesn't include `description`.

## `detect`, not `find_or_initialize_by` — this one nearly shipped as a silent bug

The helper is deliberately written this way, and the reason is not obvious:

```ruby
row = descriptions.detect { |d| d.kind == kind.to_s && d.locale == locale && d.source == source.to_s } ||
  descriptions.build(kind: kind, locale: locale, source: source)
```

`find_or_initialize_by` on a **persisted** parent issues a query and returns an instance that is **not in the association's target**. `autosave` only iterates the target, so the parent save is a silent no-op and the content never changes — precisely the failure the `autosave: true` change exists to prevent. Verified empirically on PG 17 / Rails 8.1:

| Case | Result |
|---|---|
| `find_or_initialize_by` + parent save, persisted parent, existing row | **Silently does not update** |
| ...same, association pre-loaded first | **Still does not update** |
| `detect` + parent save | Updates correctly |
| `detect` + parent save **without** `autosave: true` | **Does not update** — so the flag is genuinely required |
| `build` on a new parent, no `autosave` | Saves — new children always do |

The IGDB re-import tests are the guard: they fail if `autosave: true` is removed **or** if `detect` is refactored back. Both regressions are otherwise silent.

One subtlety found during review: the first version of those tests was **vacuous** — it used a brand-new parent, and new children autosave regardless of the flag. They now run a second `populate`/`save!` cycle against the now-persisted parent, which is the only case autosave actually covers. Confirmed by stripping the flag, watching them fail, and restoring it.

## `autosave: true` blast radius

Added to `has_many :descriptions` on a concern included by 11 models, so it got scrutiny:

- `.descriptions` appears nowhere in the repo outside `describable.rb` and the four new call sites.
- Rails only validates/saves children that are `changed_for_autosave?`, so a pre-existing invalid row cannot block an unrelated parent save — only rows this helper just touched.
- The one real delta: an invalid *changed* child now blocks its parent's save where before it was silently ignored. That's the correct trade — silent data loss is worse than a loud failure — and it has its own test.

## Review findings worth recording

**The guard tests could not fail.** The abstained/blank tests asserted `@album.reload.description`, a column the code no longer writes, so they passed regardless — you could delete `&& !data[:abstained]` and stay green. And the genuinely dangerous case, `abstained: true` *with* non-nil description text, was never tested at all. Both now assert against the `:ai_generated` row, verified by deleting the clause, watching the test fail, and restoring it.

**`**attrs` could smuggle `kind`/`locale`.** The predicate hardcoded `summary`/`en` while `**attrs` was splatted into `assign_attributes`, so `kind: :long` would have built a `summary` row, overridden it to `long`, and duplicated it on the next call against the natural-key index. They're real keyword arguments now, used in both the lookup and the build.

**A count assertion leaned on an incidental save.** `assert_difference "Description.count", 1` around `populate` only passed because `import_categories` happens to call `game.save! unless game.persisted?` mid-populate. It now asserts the in-memory association inside `populate` and keeps the DB check on the explicit save.

## Deploy ordering — c1 cannot ship to production alone

Beyond the backfill prerequisite already recorded for b1/b2, this increment adds one the spec originally missed:

After c1, a newly imported game or company, and every AI regeneration, writes **only** a `Description` row — while every public and admin view still reads the `description` **column** until increment (d). Existing data is unaffected, but anything imported *after* c1 deploys would display no description anywhere, and with no admin panel yet (c2) there would be no way to inspect the text that was written.

**So c1 needs (d) before production.** Recorded in the spec's Deploy ordering section.

## Testing

`bin/rails test`: **4,963 runs, 13,348 assertions, 0 failures, 0 errors**. `standardrb` clean. No brakeman.

New coverage: the helper's blank/whitespace rejection, build-vs-update, never-touching-`rank` (against a fixture row sitting at `preferred`), unsaved-parent support, repeat-call idempotency, kind/locale scoping, the autosave contract, the clobber regression on both music tasks, and IGDB re-import persistence for both providers. Four importer-level tests were moved off the retired column onto the row, each gaining an `assert_nil ...description` so they now positively assert the column is no longer written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
